### PR TITLE
Fixed first character removal

### DIFF
--- a/nmea.go
+++ b/nmea.go
@@ -44,7 +44,7 @@ func (s *Sentence) parse(input string) error {
 	}
 
 	// remove the $ character
-	sentence := strings.Split(s.Raw, sentenceStart)[1]
+	sentence := strings.TrimPrefix(s.Raw, sentenceStart)
 
 	fieldSum := strings.Split(sentence, checksumSep)
 	fields := strings.Split(fieldSum[0], fieldSep)


### PR DESCRIPTION
The library was crashing when the sentence contained multiple $ characters, such as:
`$GPTXT,01,01,02,u-blo?$GPTXT,01,01,02,u-b$GPTXT,01,01,02,u-bl?$GPTXT,01,01,02,u-blox ag - www.u-blox.co?$GPTXT,01,01,02,u-blox ag - www.u-blox.com*50
`
(I agree it's invalid, but that makes the library crash)