### PR TITLE
Check sentence starts with dollar ($) sign

### DIFF
--- a/nmea.go
+++ b/nmea.go
@@ -35,18 +35,23 @@ func (s Sentence) GetSentence() Sentence {
 func (s *Sentence) parse(input string) error {
 	s.Raw = input
 
-	if strings.Count(s.Raw, checksumSep) != 1 {
-		return fmt.Errorf("Sentence does not contain single checksum separator")
-	}
-
-	if !strings.Contains(s.Raw, sentenceStart) {
+	// Start the sentence from the $ character
+	startPosition := strings.LastIndex(s.Raw, sentenceStart)
+	if startPosition < 0 {
 		return fmt.Errorf("Sentence does not contain a '$'")
 	}
 
-	// remove the $ character
-	sentence := strings.Split(s.Raw, sentenceStart)[1]
+	sentence := s.Raw[startPosition+1:]
+	if startPosition > 0 {
+		// Rewrite s.Raw with the shortened sentence
+		s.Raw = s.Raw[startPosition:]
+	}
 
 	fieldSum := strings.Split(sentence, checksumSep)
+	if len(fieldSum) != 2 {
+		return fmt.Errorf("Sentence does not contain single checksum separator")
+	}
+
 	fields := strings.Split(fieldSum[0], fieldSep)
 	s.Type = fields[0]
 	s.Fields = fields[1:]

--- a/nmea.go
+++ b/nmea.go
@@ -36,16 +36,15 @@ func (s *Sentence) parse(input string) error {
 	s.Raw = input
 
 	// Start the sentence from the $ character
-	startPosition := strings.LastIndex(s.Raw, sentenceStart)
+	startPosition := strings.Index(s.Raw, sentenceStart)
 	if startPosition < 0 {
 		return fmt.Errorf("Sentence does not contain a '$'")
 	}
+	if startPosition > 0 {
+		return fmt.Errorf("Sentence does not start with a '$'")
+	}
 
 	sentence := s.Raw[startPosition+1:]
-	if startPosition > 0 {
-		// Rewrite s.Raw with the shortened sentence
-		s.Raw = s.Raw[startPosition:]
-	}
 
 	fieldSum := strings.Split(sentence, checksumSep)
 	if len(fieldSum) != 2 {

--- a/nmea_test.go
+++ b/nmea_test.go
@@ -63,38 +63,28 @@ func TestGoodRawSentence(t *testing.T) {
 	assert.Equal(t, raw, m.GetSentence().Raw, "Bad raw sentence")
 }
 
-func TestStartDelimiterSentence(t *testing.T) {
-	var sentences = []string{
-		"$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-		"abc$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-		"$$$$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-		"$GPFOO,99999,9999,99999$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-		"$GPFOO,99999,9999,99999*5$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-	}
-	expectedFields := []string{"235236", "A", "3925.9479", "N", "11945.9211", "W", "44.7", "153.6", "250905", "15.2", "E", "A"}
-
-	for _, sentence := range sentences {
-		m, err := Parse(sentence)
-		assert.NotNil(t, m, "Result should be not nil")
-		assert.Nil(t, err, "Err should be nil")
-		assert.EqualValues(t, expectedFields, m.GetSentence().Fields, "Got '%q', expected '%q'", m.GetSentence().Fields, expectedFields)
-	}
+func TestMultipleStartDelimiterSentence(t *testing.T) {
+	raw := "$$$$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
+	result, err := Parse(raw)
+	assert.Nil(t, result, "Result should be nil")
+	assert.NotNil(t, err, "Err should be an error")
+	assert.Equal(t, "Sentence checksum mismatch [28 != 0C]", err.Error(), "Error sentence mismatch")
 }
 
 func TestNoStartDelimiterSentence(t *testing.T) {
+	raw := "abc$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
+	result, err := Parse(raw)
+	assert.Nil(t, result, "Result should be nil")
+	assert.NotNil(t, err, "Err should be an error")
+	assert.Equal(t, "Sentence does not start with a '$'", err.Error(), "Error sentence mismatch")
+}
+
+func TestNoContainDelimiterSentence(t *testing.T) {
 	raw := "GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
 	result, err := Parse(raw)
 	assert.Nil(t, result, "Result should be nil")
 	assert.NotNil(t, err, "Err should be an error")
 	assert.Equal(t, "Sentence does not contain a '$'", err.Error(), "Error sentence mismatch")
-}
-
-func TestNoChecksum(t *testing.T) {
-	raw := "$GPFOO,99999,9999,99999*5$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A"
-	result, err := Parse(raw)
-	assert.Nil(t, result, "Result should be nil")
-	assert.NotNil(t, err, "Err should be an error")
-	assert.Equal(t, "Sentence does not contain single checksum separator", err.Error(), "Error sentence mismatch")
 }
 
 func TestReturnValues(t *testing.T) {

--- a/nmea_test.go
+++ b/nmea_test.go
@@ -1,72 +1,106 @@
 package nmea
 
 import (
-  "testing"
+	"testing"
 
-  "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChecksumOK(t *testing.T) {
-  s := Sentence{Raw: "$GPFOO,1,2,3.3,x,y,zz,*51", Checksum: "51"}
-  assert.NoError(t, s.sumOk(), "Checksum check failed")
+	s := Sentence{Raw: "$GPFOO,1,2,3.3,x,y,zz,*51", Checksum: "51"}
+	assert.NoError(t, s.sumOk(), "Checksum check failed")
 }
 
 func TestChecksumBad(t *testing.T) {
-  s := Sentence{Raw: "$GPFOO,1,2,3.3,x,y,zz,*51", Checksum: "2C"}
-  assert.Error(t, s.sumOk(), "Expected '[51 != 2C]'")
+	s := Sentence{Raw: "$GPFOO,1,2,3.3,x,y,zz,*51", Checksum: "2C"}
+	assert.Error(t, s.sumOk(), "Expected '[51 != 2C]'")
 }
 
 func TestChecksumBadRaw(t *testing.T) {
-  badRaw := "$GPFOO,1,2,3.3,x,y,zz,*33"
-  _, err := Parse(badRaw)
-  assert.Error(t, err, "Expected 'Sentence checksum mismatch [51 != 33]'")
+	badRaw := "$GPFOO,1,2,3.3,x,y,zz,*33"
+	_, err := Parse(badRaw)
+	assert.Error(t, err, "Expected 'Sentence checksum mismatch [51 != 33]'")
 }
 
 func TestBadStartCharacter(t *testing.T) {
-  // Check that a bad start character is flagged.
-  rawBadStart := "%GPFOO,1,2,3,x,y,z*1A"
-  _, err := Parse(rawBadStart)
-  assert.Error(t, err, "Expected 'Sentence does not contain a '$''")
+	// Check that a bad start character is flagged.
+	rawBadStart := "%GPFOO,1,2,3,x,y,z*1A"
+	_, err := Parse(rawBadStart)
+	assert.Error(t, err, "Expected 'Sentence does not contain a '$''")
 }
 
 func TestBadChecksumDelimiter(t *testing.T) {
-  // Check that a bad checksum delimiter is flagged.
-  rawBadSumSep := "$GPFOO,1,2,3,x,y,z"
-  _, err := Parse(rawBadSumSep)
-  assert.Error(t, err, "Expected 'Sentence does not contain single checksum separator'")
+	// Check that a bad checksum delimiter is flagged.
+	rawBadSumSep := "$GPFOO,1,2,3,x,y,z"
+	_, err := Parse(rawBadSumSep)
+	assert.Error(t, err, "Expected 'Sentence does not contain single checksum separator'")
 }
 
 func TestGoodParsing(t *testing.T) {
-  // Check for good parsing.
-  raw := "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
-  _, err := Parse(raw)
-  assert.NoError(t, err, "Parse error")
+	// Check for good parsing.
+	raw := "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
+	_, err := Parse(raw)
+	assert.NoError(t, err, "Parse error")
 }
 
 func TestGoodFields(t *testing.T) {
-  raw := "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
-  expectedFields := []string{"235236", "A", "3925.9479", "N", "11945.9211", "W", "44.7", "153.6", "250905", "15.2", "E", "A"}
-  m, _ := Parse(raw)
-  assert.EqualValues(t, expectedFields, m.GetSentence().Fields, "Got '%q', expected '%q'", m.GetSentence().Fields, expectedFields)
+	raw := "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
+	expectedFields := []string{"235236", "A", "3925.9479", "N", "11945.9211", "W", "44.7", "153.6", "250905", "15.2", "E", "A"}
+	m, _ := Parse(raw)
+	assert.EqualValues(t, expectedFields, m.GetSentence().Fields, "Got '%q', expected '%q'", m.GetSentence().Fields, expectedFields)
 }
 
 func TestGoodSentenceType(t *testing.T) {
-  raw := "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
-  expected := "GPRMC"
-  m, _ := Parse(raw)
-  assert.Equal(t, expected, m.GetSentence().Type, "Got '%s', expected '%s'", m.GetSentence().Type, expected)
+	raw := "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
+	expected := "GPRMC"
+	m, _ := Parse(raw)
+	assert.Equal(t, expected, m.GetSentence().Type, "Got '%s', expected '%s'", m.GetSentence().Type, expected)
 }
 
 func TestGoodRawSentence(t *testing.T) {
-  raw := "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
-  m, _ := Parse(raw)
-  assert.Equal(t, raw, m.GetSentence().Raw, "Bad raw sentence")
+	raw := "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
+	m, _ := Parse(raw)
+	assert.Equal(t, raw, m.GetSentence().Raw, "Bad raw sentence")
+}
+
+func TestStartDelimiterSentence(t *testing.T) {
+	var sentences = []string{
+		"$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
+		"abc$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
+		"$$$$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
+		"$GPFOO,99999,9999,99999$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
+		"$GPFOO,99999,9999,99999*5$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
+	}
+	expectedFields := []string{"235236", "A", "3925.9479", "N", "11945.9211", "W", "44.7", "153.6", "250905", "15.2", "E", "A"}
+
+	for _, sentence := range sentences {
+		m, err := Parse(sentence)
+		assert.NotNil(t, m, "Result should be not nil")
+		assert.Nil(t, err, "Err should be nil")
+		assert.EqualValues(t, expectedFields, m.GetSentence().Fields, "Got '%q', expected '%q'", m.GetSentence().Fields, expectedFields)
+	}
+}
+
+func TestNoStartDelimiterSentence(t *testing.T) {
+	raw := "GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C"
+	result, err := Parse(raw)
+	assert.Nil(t, result, "Result should be nil")
+	assert.NotNil(t, err, "Err should be an error")
+	assert.Equal(t, "Sentence does not contain a '$'", err.Error(), "Error sentence mismatch")
+}
+
+func TestNoChecksum(t *testing.T) {
+	raw := "$GPFOO,99999,9999,99999*5$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A"
+	result, err := Parse(raw)
+	assert.Nil(t, result, "Result should be nil")
+	assert.NotNil(t, err, "Err should be an error")
+	assert.Equal(t, "Sentence does not contain single checksum separator", err.Error(), "Error sentence mismatch")
 }
 
 func TestReturnValues(t *testing.T) {
-  // Ensure Parse returns errors when appropriate.
-  result, err := Parse("$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0A")
-  assert.Nil(t, result, "Result should be nil")
-  assert.NotNil(t, err, "Err should be an error")
-  assert.Equal(t, "Sentence checksum mismatch [0C != 0A]", err.Error(), "Error sentence mismatch")
+	// Ensure Parse returns errors when appropriate.
+	result, err := Parse("$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0A")
+	assert.Nil(t, result, "Result should be nil")
+	assert.NotNil(t, err, "Err should be an error")
+	assert.Equal(t, "Sentence checksum mismatch [0C != 0A]", err.Error(), "Error sentence mismatch")
 }


### PR DESCRIPTION
Actually, my issue is that I have some malformed NMEA sentences due to serial communication issues, which led to a crash in the library. My intention here is simply to avoid the crash, not necessarily to recover from it.
However, reading a bit about NMEA, it seems that $ is a "start delimiter", so I agree with your solution to start reading from the last $.
I'm checking the * after splitting.
I also added some tests.