### PR TITLE
Added support for $GNRMC, $GLGSV and $GNGGA sentences.

### DIFF
--- a/glgsv.go
+++ b/glgsv.go
@@ -1,0 +1,109 @@
+package nmea
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	// PrefixGLGSV prefix
+	PrefixGLGSV = "GLGSV"
+)
+
+// GLGSV represents the GPS Satellites in view
+// http://aprs.gids.nl/nmea/#glgsv
+type GLGSV struct {
+	Sentence
+	TotalMessages   int64 // Total number of messages of this type in this cycle
+	MessageNumber   int64 // Message number
+	NumberSVsInView int64 // Total number of SVs in view
+
+	Info []GLGSVInfo // visible satellite info (0-4 of these)
+}
+
+// GLGSVInfo represents information about a visible satellite
+type GLGSVInfo struct {
+	SVPRNNumber int64 // SV PRN number, pseudo-random noise or gold code
+	Elevation   int64 // Elevation in degrees, 90 maximum
+	Azimuth     int64 // Azimuth, degrees from true north, 000 to 359
+	SNR         int64 // SNR, 00-99 dB (null when not tracking)
+}
+
+// NewGLGSV constructor
+func NewGLGSV(sentence Sentence) GLGSV {
+	return GLGSV{Sentence: sentence}
+}
+
+// GetSentence getter
+func (s GLGSV) GetSentence() Sentence {
+	return s.Sentence
+}
+
+func (s *GLGSV) parse() error {
+	if s.Type != PrefixGLGSV {
+		return fmt.Errorf("%s is not a %s", s.Type, PrefixGLGSV)
+	}
+	var err error
+	if s.Fields[0] != "" {
+		s.TotalMessages, err = strconv.ParseInt(s.Fields[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("GLGSV decode total number of messages error: %s", s.Fields[0])
+		}
+	}
+
+	if s.Fields[1] != "" {
+		s.MessageNumber, err = strconv.ParseInt(s.Fields[1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("GLGSV decode message number error: %s", s.Fields[1])
+		}
+	}
+
+	if s.Fields[2] != "" {
+		s.NumberSVsInView, err = strconv.ParseInt(s.Fields[2], 10, 64)
+		if err != nil {
+			return fmt.Errorf("GLGSV decode number of SVs in view error: %s", s.Fields[2])
+		}
+	}
+
+	s.Info = nil
+	for i := 0; i < 4; i++ {
+		if 5*i+4 > len(s.Fields) {
+			break
+		}
+		info := GLGSVInfo{}
+		field := s.Fields[3+i*4]
+		if s.Fields[3+i*4] != "" {
+			info.SVPRNNumber, err = strconv.ParseInt(field, 10, 64)
+			if err != nil {
+				return fmt.Errorf("GLGSV decode SV prn number error: %s", field)
+			}
+		}
+
+		field = s.Fields[4+i*4]
+		if field != "" {
+			info.Elevation, err = strconv.ParseInt(field, 10, 64)
+			if err != nil {
+				return fmt.Errorf("GLGSV decode elevation error: %s", field)
+			}
+		}
+
+		field = s.Fields[5+i*4]
+		if field != "" {
+			info.Azimuth, err = strconv.ParseInt(field, 10, 64)
+			if err != nil {
+				return fmt.Errorf("GLGSV decode azimuth error: %s", field)
+			}
+		}
+
+		field = s.Fields[6+i*4]
+		if field != "" {
+			info.SNR, err = strconv.ParseInt(field, 10, 64)
+			if err != nil {
+				return fmt.Errorf("GLGSV decode SNR error: %s", field)
+			}
+		}
+		s.Info = append(s.Info, info)
+	}
+
+	return nil
+}

--- a/glgsv_test.go
+++ b/glgsv_test.go
@@ -1,0 +1,98 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGLGSVGoodSentence(t *testing.T) {
+	goodMsg := "$GLGSV,3,1,11,03,03,111,00,04,15,270,00,06,01,010,12,13,06,292,00*6B"
+	s, err := Parse(goodMsg)
+
+	assert.NoError(t, err, "Unexpected error parsing good sentence")
+	assert.Equal(t, PrefixGLGSV, s.GetSentence().Type, "Prefix does not match")
+
+	sentence := s.(GLGSV)
+	assert.Equal(t, int64(3), sentence.TotalMessages, "Total messages does not match")
+	assert.Equal(t, int64(1), sentence.MessageNumber, "Message number does not match")
+	assert.Equal(t, int64(11), sentence.NumberSVsInView, "Number of SVs in view does not match")
+
+	assert.Equal(t, int64(3), sentence.Info[0].SVPRNNumber, "Number of Info[0] SV PRN does not match")
+	assert.Equal(t, int64(3), sentence.Info[0].Elevation, "Number of Info[0] Elevation does not match")
+	assert.Equal(t, int64(111), sentence.Info[0].Azimuth, "Number of Info[0] Azimuth does not match")
+	assert.Equal(t, int64(0), sentence.Info[0].SNR, "Number of Info[0] SNR does not match")
+
+	assert.Equal(t, int64(4), sentence.Info[1].SVPRNNumber, "Number of Info[1] SV PRN does not match")
+	assert.Equal(t, int64(15), sentence.Info[1].Elevation, "Number of Info[1] Elevation does not match")
+	assert.Equal(t, int64(270), sentence.Info[1].Azimuth, "Number of Info[1] Azimuth does not match")
+	assert.Equal(t, int64(0), sentence.Info[1].SNR, "Number of Info[1] SNR does not match")
+
+	assert.Equal(t, int64(6), sentence.Info[2].SVPRNNumber, "Number of Info[2] SV PRN does not match")
+	assert.Equal(t, int64(1), sentence.Info[2].Elevation, "Number of Info[2] Elevation does not match")
+	assert.Equal(t, int64(10), sentence.Info[2].Azimuth, "Number of Info[2] Azimuth does not match")
+	assert.Equal(t, int64(12), sentence.Info[2].SNR, "Number of Info[2] SNR does not match")
+
+	assert.Equal(t, int64(13), sentence.Info[3].SVPRNNumber, "Number of Info[3] SV PRN does not match")
+	assert.Equal(t, int64(6), sentence.Info[3].Elevation, "Number of Info[3] Elevation does not match")
+	assert.Equal(t, int64(292), sentence.Info[3].Azimuth, "Number of Info[3] Azimuth does not match")
+	assert.Equal(t, int64(0), sentence.Info[3].SNR, "Number of Info[3] SNR does not match")
+}
+
+func TestGLGSVShort(t *testing.T) {
+	goodMsg := "$GLGSV,3,1,11,03,03,111,00,04,15,270,00,06,01,010,12*56"
+	s, err := Parse(goodMsg)
+
+	assert.NoError(t, err, "Unexpected error parsing good sentence")
+	assert.Equal(t, PrefixGLGSV, s.GetSentence().Type, "Prefix does not match")
+
+	sentence := s.(GLGSV)
+	assert.Equal(t, int64(3), sentence.TotalMessages, "Total messages does not match")
+	assert.Equal(t, int64(1), sentence.MessageNumber, "Message number does not match")
+	assert.Equal(t, int64(11), sentence.NumberSVsInView, "Number of SVs in view does not match")
+
+	assert.Equal(t, int64(3), sentence.Info[0].SVPRNNumber, "Number of Info[0] SV PRN does not match")
+	assert.Equal(t, int64(3), sentence.Info[0].Elevation, "Number of Info[0] Elevation does not match")
+	assert.Equal(t, int64(111), sentence.Info[0].Azimuth, "Number of Info[0] Azimuth does not match")
+	assert.Equal(t, int64(0), sentence.Info[0].SNR, "Number of Info[0] SNR does not match")
+
+	assert.Equal(t, int64(4), sentence.Info[1].SVPRNNumber, "Number of Info[1] SV PRN does not match")
+	assert.Equal(t, int64(15), sentence.Info[1].Elevation, "Number of Info[1] Elevation does not match")
+	assert.Equal(t, int64(270), sentence.Info[1].Azimuth, "Number of Info[1] Azimuth does not match")
+	assert.Equal(t, int64(0), sentence.Info[1].SNR, "Number of Info[1] SNR does not match")
+
+	assert.Equal(t, int64(6), sentence.Info[2].SVPRNNumber, "Number of Info[2] SV PRN does not match")
+	assert.Equal(t, int64(1), sentence.Info[2].Elevation, "Number of Info[2] Elevation does not match")
+	assert.Equal(t, int64(10), sentence.Info[2].Azimuth, "Number of Info[2] Azimuth does not match")
+	assert.Equal(t, int64(12), sentence.Info[2].SNR, "Number of Info[2] SNR does not match")
+}
+func TestGLGSVBadSentence(t *testing.T) {
+	tests := []struct {
+		Input string
+		Error string
+	}{
+		{"$GLGSV,3,1,11.2,03,03,111,00,04,15,270,00,06,01,010,12,13,06,292,00*77", "GLGSV decode number of SVs in view error: 11.2"},
+		{"$GLGSV,A3,1,11,03,03,111,00,04,15,270,00,06,01,010,12,13,06,292,00*2A", "GLGSV decode total number of messages error: A3"},
+		{"$GLGSV,3,A1,11,03,03,111,00,04,15,270,00,06,01,010,12,13,06,292,00*2A", "GLGSV decode message number error: A1"},
+		{"$GLGSV,3,1,11,A03,03,111,00,04,15,270,00,06,01,010,12,13,06,292,00*2A", "GLGSV decode SV prn number error: A03"},
+		{"$GLGSV,3,1,11,03,A03,111,00,04,15,270,00,06,01,010,12,13,06,292,00*2A", "GLGSV decode elevation error: A03"},
+		{"$GLGSV,3,1,11,03,03,A111,00,04,15,270,00,06,01,010,12,13,06,292,00*2A", "GLGSV decode azimuth error: A111"},
+		{"$GLGSV,3,1,11,03,03,111,A00,04,15,270,00,06,01,010,12,13,06,292,00*2A", "GLGSV decode SNR error: A00"},
+	}
+	for _, tc := range tests {
+		_, err := Parse(tc.Input)
+		assert.Error(t, err, "Parse error not returned")
+		assert.Equal(t, tc.Error, err.Error(), "Incorrect error message")
+	}
+
+}
+
+func TestGLGSVWrongSentence(t *testing.T) {
+	wrongMsg := "$GPXTE,A,A,4.07,L,N*6D"
+	sent := Sentence{}
+	sent.parse(wrongMsg)
+	msg := GLGSV{Sentence: sent}
+	err := msg.parse()
+	assert.Error(t, err, "Parse error not returned")
+	assert.Equal(t, "GPXTE is not a GLGSV", err.Error(), "Incorrect error message")
+}

--- a/gngga.go
+++ b/gngga.go
@@ -1,0 +1,70 @@
+package nmea
+
+import "fmt"
+
+const (
+	// PrefixGNGGA prefix
+	PrefixGNGGA = "GNGGA"
+)
+
+type GNGGA struct {
+	Sentence
+	// Time of fix.
+	Time string
+	// Latitude.
+	Latitude LatLong
+	// Longitude.
+	Longitude LatLong
+	// Quality of fix.
+	FixQuality string
+	// Number of satellites in use.
+	NumSatellites string
+	// Horizontal dilution of precision.
+	HDOP string
+	// Altitude.
+	Altitude string
+	// Geoidal separation
+	Separation string
+	// Age of differential GPD data.
+	DGPSAge string
+	// DGPS reference station ID.
+	DGPSId string
+}
+
+func NewGNGGA(sentence Sentence) GNGGA {
+	s := new(GNGGA)
+	s.Sentence = sentence
+	return *s
+}
+
+func (s GNGGA) GetSentence() Sentence {
+	return s.Sentence
+}
+
+func (s *GNGGA) parse() error {
+	var err error
+
+	if s.Type != PrefixGNGGA {
+		return fmt.Errorf("%s is not a %s", s.Type, PrefixGNGGA)
+	}
+	s.Time = s.Fields[0]
+	s.Latitude, err = NewLatLong(fmt.Sprintf("%s %s", s.Fields[1], s.Fields[2]))
+	if err != nil {
+		return fmt.Errorf("GNGGA decode error: %s", err)
+	}
+	s.Longitude, err = NewLatLong(fmt.Sprintf("%s %s", s.Fields[3], s.Fields[4]))
+	if err != nil {
+		return fmt.Errorf("GNGGA decode error: %s", err)
+	}
+	s.FixQuality = s.Fields[5]
+	if s.FixQuality != Invalid && s.FixQuality != GPS && s.FixQuality != DGPS {
+		return fmt.Errorf("Invalid fix quality [%s]", s.FixQuality)
+	}
+	s.NumSatellites = s.Fields[6]
+	s.HDOP = s.Fields[7]
+	s.Altitude = s.Fields[8]
+	s.Separation = s.Fields[10]
+	s.DGPSAge = s.Fields[12]
+	s.DGPSId = s.Fields[13]
+	return nil
+}

--- a/gngga_test.go
+++ b/gngga_test.go
@@ -1,0 +1,71 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGNGGAGoodSentence(t *testing.T) {
+	goodMsg := "$GNGGA,203415.000,6325.6138,N,01021.4290,E,1,8,2.42,72.5,M,41.5,M,,*7C"
+	sentence, err := Parse(goodMsg)
+
+	assert.NoError(t, err, "Unexpected error parsing good sentence")
+
+	lat, _ := NewLatLong("6325.6138 N")
+	lon, _ := NewLatLong("01021.4290 E")
+	// Attributes of the parsed sentence, and their expected values.
+	expected := GNGGA{
+		Sentence: Sentence{
+			Type:     "GNGGA",
+			Fields:   []string{"203415.000", "6325.6138", "N", "01021.4290", "E", "1", "8", "2.42", "72.5", "M", "41.5", "M", "", ""},
+			Checksum: "7C",
+			Raw:      "$GNGGA,203415.000,6325.6138,N,01021.4290,E,1,8,2.42,72.5,M,41.5,M,,*7C",
+		},
+		Time:          "203415.000",
+		Latitude:      lat,
+		Longitude:     lon,
+		FixQuality:    GPS,
+		NumSatellites: "8",
+		HDOP:          "2.42",
+		Altitude:      "72.5",
+		Separation:    "41.5",
+		DGPSAge:       "",
+		DGPSId:        "",
+	}
+
+	assert.EqualValues(t, expected, sentence, "Sentence values do not match")
+}
+
+func TestGNGGABadType(t *testing.T) {
+	badType := "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70"
+	s, err := Parse(badType)
+
+	assert.NoError(t, err, "Unexpected error parsing sentence")
+	assert.NotEqual(t, "GNGGA", s.GetSentence().Type, "Unexpected sentence type")
+}
+
+func TestGNGGABadLatitude(t *testing.T) {
+	badLat := "$GNGGA,034225.077,A,S,15124.5567,E,1,03,9.7,-25.0,M,21.0,M,,0000*24"
+	_, err := Parse(badLat)
+
+	assert.Error(t, err, "Parse error not returned")
+	assert.Equal(t, "GNGGA decode error: cannot parse [A S], unknown format", err.Error(), "Error message does not match")
+}
+
+func TestGNGGABadLongitude(t *testing.T) {
+	badLon := "$GNGGA,034225.077,3356.4650,S,A,E,1,03,9.7,-25.0,M,21.0,M,,0000*12"
+	_, err := Parse(badLon)
+
+	assert.Error(t, err, "Parse error not returned")
+	assert.Equal(t, "GNGGA decode error: cannot parse [A E], unknown format", err.Error(), "Error message does not match")
+}
+
+func TestGNGGABadFixQuality(t *testing.T) {
+	// Make sure bad fix mode is detected.
+	badMode := "$GNGGA,034225.077,3356.4650,S,15124.5567,E,5,03,9.7,-25.0,M,21.0,M,,0000*4B"
+	_, err := Parse(badMode)
+
+	assert.Error(t, err, "Parse error not returned")
+	assert.Equal(t, err.Error(), "Invalid fix quality [5]", "Error message not as expected")
+}

--- a/gnrmc.go
+++ b/gnrmc.go
@@ -1,0 +1,87 @@
+package nmea
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	// PrefixGNRMC prefix of GNRMC sentence type
+	PrefixGNRMC = "GNRMC"
+)
+
+// GNRMC is the Recommended Minimum Specific GNSS data.
+// http://aprs.gids.nl/nmea/#rmc
+type GNRMC struct {
+	Sentence
+	Time      string  // Time Stamp
+	Validity  string  // validity - A-ok, V-invalid
+	Latitude  LatLong // Latitude
+	Longitude LatLong // Longitude
+	Speed     float64 // Speed in knots
+	Course    float64 // True course
+	Date      string  // Date
+	Variation float64 // Magnetic variation
+}
+
+// NewGNRMC constructor
+func NewGNRMC(sentence Sentence) GNRMC {
+	s := new(GNRMC)
+	s.Sentence = sentence
+	return *s
+}
+
+// GetSentence getter
+func (s GNRMC) GetSentence() Sentence {
+	return s.Sentence
+}
+
+func (s *GNRMC) parse() error {
+	var err error
+
+	if s.Type != PrefixGNRMC {
+		return fmt.Errorf("%s is not a %s", s.Type, PrefixGNRMC)
+	}
+	s.Time = s.Fields[0]
+	s.Validity = s.Fields[1]
+
+	if s.Validity != ValidRMC && s.Validity != InvalidRMC {
+		return fmt.Errorf("GNRMC decode, invalid validity '%s'", s.Validity)
+	}
+
+	s.Latitude, err = NewLatLong(fmt.Sprintf("%s %s", s.Fields[2], s.Fields[3]))
+	if err != nil {
+		return fmt.Errorf("GNRMC decode latitude error: %s", err)
+	}
+	s.Longitude, err = NewLatLong(fmt.Sprintf("%s %s", s.Fields[4], s.Fields[5]))
+	if err != nil {
+		return fmt.Errorf("GNRMC decode longitude error: %s", err)
+	}
+	if s.Fields[6] != "" {
+		s.Speed, err = strconv.ParseFloat(s.Fields[6], 64)
+		if err != nil {
+			return fmt.Errorf("GNRMC decode speed error: %s", s.Fields[6])
+		}
+	}
+	if s.Fields[7] != "" {
+		s.Course, err = strconv.ParseFloat(s.Fields[7], 64)
+		if err != nil {
+			return fmt.Errorf("GNRMC decode course error: %s", s.Fields[7])
+		}
+	}
+	s.Date = s.Fields[8]
+
+	if s.Fields[9] != "" {
+		s.Variation, err = strconv.ParseFloat(s.Fields[9], 64)
+		if err != nil {
+			return fmt.Errorf("GNRMC decode variation error: %s", s.Fields[9])
+		}
+		if s.Fields[10] == "W" {
+			s.Variation = 0 - s.Variation
+		} else if s.Fields[10] != "E" {
+			return fmt.Errorf("GNRMC decode variation error for: %s", s.Fields[10])
+		}
+	}
+
+	return nil
+}

--- a/gnrmc_test.go
+++ b/gnrmc_test.go
@@ -1,0 +1,78 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var gnrmctests = []struct {
+	Input  string
+	Output GNRMC
+}{
+	{
+		"$GNRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*6E",
+		GNRMC{
+			Time:      "220516",
+			Validity:  "A",
+			Speed:     173.8,
+			Course:    231.8,
+			Date:      "130694",
+			Variation: -4.2,
+			Latitude:  MustParseGPS("5133.82 N"),
+			Longitude: MustParseGPS("00042.24 W"),
+		},
+	},
+	{
+		"$GNRMC,142754.0,A,4302.539570,N,07920.379823,W,0.0,,070617,0.0,E,A*21",
+		GNRMC{
+			Time:      "142754.0",
+			Validity:  "A",
+			Speed:     0,
+			Course:    0,
+			Date:      "070617",
+			Variation: 0,
+			Latitude:  MustParseGPS("4302.539570 N"),
+			Longitude: MustParseGPS("07920.379823 W"),
+		},
+	},
+}
+
+func TestGNRMCGoodSentence(t *testing.T) {
+
+	for _, tt := range gnrmctests {
+
+		s, err := Parse(tt.Input)
+
+		assert.NoError(t, err, "Unexpected error parsing good sentence")
+		assert.Equal(t, PrefixGNRMC, s.GetSentence().Type, "Prefix does not match")
+
+		sentence := s.(GNRMC)
+
+		assert.Equal(t, tt.Output.Time, sentence.Time, "Time does not match")
+		assert.Equal(t, tt.Output.Validity, sentence.Validity, "Status does not match")
+		assert.Equal(t, tt.Output.Speed, sentence.Speed, "Speed does not match")
+		assert.Equal(t, tt.Output.Course, sentence.Course, "Course does not match")
+		assert.Equal(t, tt.Output.Date, sentence.Date, "Date does not match")
+		assert.Equal(t, tt.Output.Variation, sentence.Variation, "Variation does not match")
+		assert.Equal(t, tt.Output.Latitude, sentence.Latitude, "Latitude does not match")
+		assert.Equal(t, tt.Output.Longitude, sentence.Longitude, "Longitude does not match")
+	}
+
+}
+
+func TestGNRMCBadSentence(t *testing.T) {
+	badMsg := "$GNRMC,220516,D,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*6B"
+	_, err := Parse(badMsg)
+
+	assert.Error(t, err, "Parse error not returned")
+	assert.Equal(t, "GNRMC decode, invalid validity 'D'", err.Error(), "Incorrect error message")
+}
+
+func TestGNRMCWrongSentence(t *testing.T) {
+	wrongMsg := "$GPXTE,A,A,4.07,L,N*6D"
+	_, err := Parse(wrongMsg)
+
+	assert.Error(t, err, "Parse error not returned")
+	assert.Equal(t, "Sentence type 'GPXTE' not implemented", err.Error(), "Incorrect error message")
+}

--- a/nmea.go
+++ b/nmea.go
@@ -93,12 +93,24 @@ func Parse(s string) (SentenceI, error) {
 			return nil, err
 		}
 		return gprmc, nil
+	} else if sentence.Type == PrefixGNRMC {
+		gnrmc := NewGNRMC(sentence)
+		if err := gnrmc.parse(); err != nil {
+			return nil, err
+		}
+		return gnrmc, nil
 	} else if sentence.Type == PrefixGPGGA {
 		gpgga := NewGPGGA(sentence)
 		if err := gpgga.parse(); err != nil {
 			return nil, err
 		}
 		return gpgga, nil
+	} else if sentence.Type == PrefixGNGGA {
+		gngga := NewGNGGA(sentence)
+		if err := gngga.parse(); err != nil {
+			return nil, err
+		}
+		return gngga, nil
 	} else if sentence.Type == PrefixGPGSA {
 		gpgsa := NewGPGSA(sentence)
 		if err := gpgsa.parse(); err != nil {
@@ -135,6 +147,12 @@ func Parse(s string) (SentenceI, error) {
 			return nil, err
 		}
 		return gpgsv, nil
+	} else if sentence.Type == PrefixGLGSV {
+		glgsv := NewGLGSV(sentence)
+		if err := glgsv.parse(); err != nil {
+			return nil, err
+		}
+		return glgsv, nil
 	}
 
 	err := fmt.Errorf("Sentence type '%s' not implemented", sentence.Type)


### PR DESCRIPTION
This adds support for GLONASS.

Ideally an NMEA parser would interpret sentences so that it can work
with multiple talker identifiers (specified by the two first
characters after '$'), but these changes just extend the library
without disrupting the structure of it.