### PR TITLE
Rename symbols and eliminate useless method

### DIFF
--- a/glgsv.go
+++ b/glgsv.go
@@ -8,7 +8,7 @@ const (
 // GLGSV represents the GPS Satellites in view
 // http://aprs.gids.nl/nmea/#glgsv
 type GLGSV struct {
-	Sent
+	BaseSentence
 	TotalMessages   int64       // Total number of messages of this type in this cycle
 	MessageNumber   int64       // Message number
 	NumberSVsInView int64       // Total number of SVs in view
@@ -24,10 +24,10 @@ type GLGSVInfo struct {
 }
 
 // NewGLGSV constructor
-func NewGLGSV(s Sent) (GLGSV, error) {
+func NewGLGSV(s BaseSentence) (GLGSV, error) {
 	p := newParser(s, PrefixGLGSV)
 	m := GLGSV{
-		Sent:            s,
+		BaseSentence:    s,
 		TotalMessages:   p.Int64(0, "total number of messages"),
 		MessageNumber:   p.Int64(1, "message number"),
 		NumberSVsInView: p.Int64(2, "number of SVs in view"),

--- a/glgsv_test.go
+++ b/glgsv_test.go
@@ -88,7 +88,7 @@ func TestGLGSV(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				glgsv := m.(GLGSV)
-				glgsv.Sent = Sent{}
+				glgsv.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, glgsv)
 			}
 		})

--- a/gngga.go
+++ b/gngga.go
@@ -7,7 +7,7 @@ const (
 
 // GNGGA is the Time, position, and fix related data of the receiver.
 type GNGGA struct {
-	Sent
+	BaseSentence
 	Time          Time    // Time of fix.
 	Latitude      LatLong // Latitude.
 	Longitude     LatLong // Longitude.
@@ -21,10 +21,10 @@ type GNGGA struct {
 }
 
 // NewGNGGA constructor
-func NewGNGGA(s Sent) (GNGGA, error) {
+func NewGNGGA(s BaseSentence) (GNGGA, error) {
 	p := newParser(s, PrefixGNGGA)
 	return GNGGA{
-		Sent:          s,
+		BaseSentence:  s,
 		Time:          p.Time(0, "time"),
 		Latitude:      p.LatLong(1, 2, "latitude"),
 		Longitude:     p.LatLong(3, 4, "longitude"),

--- a/gngga_test.go
+++ b/gngga_test.go
@@ -61,7 +61,7 @@ func TestGNGGA(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gngga := m.(GNGGA)
-				gngga.Sent = Sent{}
+				gngga.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gngga)
 			}
 		})

--- a/gnrmc.go
+++ b/gnrmc.go
@@ -8,7 +8,7 @@ const (
 // GNRMC is the Recommended Minimum Specific GNSS data.
 // http://aprs.gids.nl/nmea/#rmc
 type GNRMC struct {
-	Sent
+	BaseSentence
 	Time      Time    // Time Stamp
 	Validity  string  // validity - A-ok, V-invalid
 	Latitude  LatLong // Latitude
@@ -20,18 +20,18 @@ type GNRMC struct {
 }
 
 // NewGNRMC constructor
-func NewGNRMC(s Sent) (GNRMC, error) {
+func NewGNRMC(s BaseSentence) (GNRMC, error) {
 	p := newParser(s, PrefixGNRMC)
 	m := GNRMC{
-		Sent:      s,
-		Time:      p.Time(0, "time"),
-		Validity:  p.EnumString(1, "validity", ValidRMC, InvalidRMC),
-		Latitude:  p.LatLong(2, 3, "latitude"),
-		Longitude: p.LatLong(4, 5, "longitude"),
-		Speed:     p.Float64(6, "speed"),
-		Course:    p.Float64(7, "course"),
-		Date:      p.Date(8, "date"),
-		Variation: p.Float64(9, "variation"),
+		BaseSentence: s,
+		Time:         p.Time(0, "time"),
+		Validity:     p.EnumString(1, "validity", ValidRMC, InvalidRMC),
+		Latitude:     p.LatLong(2, 3, "latitude"),
+		Longitude:    p.LatLong(4, 5, "longitude"),
+		Speed:        p.Float64(6, "speed"),
+		Course:       p.Float64(7, "course"),
+		Date:         p.Date(8, "date"),
+		Variation:    p.Float64(9, "variation"),
 	}
 	if p.EnumString(10, "direction", West, East) == West {
 		m.Variation = 0 - m.Variation

--- a/gnrmc_test.go
+++ b/gnrmc_test.go
@@ -71,7 +71,7 @@ func TestGNRMC(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gnrmc := m.(GNRMC)
-				gnrmc.Sent = Sent{}
+				gnrmc.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gnrmc)
 			}
 		})

--- a/gpgga.go
+++ b/gpgga.go
@@ -20,7 +20,7 @@ const (
 // GPGGA represents fix data.
 // http://aprs.gids.nl/nmea/#gga
 type GPGGA struct {
-	Sent
+	BaseSentence
 	Time          Time    // Time of fix.
 	Latitude      LatLong // Latitude.
 	Longitude     LatLong // Longitude.
@@ -35,10 +35,10 @@ type GPGGA struct {
 
 // NewGPGGA parses the GPGGA sentence into this struct.
 // e.g: $GPGGA,034225.077,3356.4650,S,15124.5567,E,1,03,9.7,-25.0,M,21.0,M,,0000*58
-func NewGPGGA(s Sent) (GPGGA, error) {
+func NewGPGGA(s BaseSentence) (GPGGA, error) {
 	p := newParser(s, PrefixGPGGA)
 	return GPGGA{
-		Sent:          s,
+		BaseSentence:  s,
 		Time:          p.Time(0, "time"),
 		Latitude:      p.LatLong(1, 2, "latitude"),
 		Longitude:     p.LatLong(3, 4, "longitude"),

--- a/gpgga_test.go
+++ b/gpgga_test.go
@@ -55,7 +55,7 @@ func TestGPGGA(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gpgga := m.(GPGGA)
-				gpgga.Sent = Sent{}
+				gpgga.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gpgga)
 			}
 		})

--- a/gpgll.go
+++ b/gpgll.go
@@ -12,7 +12,7 @@ const (
 // GPGLL is Geographic Position, Latitude / Longitude and time.
 // http://aprs.gids.nl/nmea/#gll
 type GPGLL struct {
-	Sent
+	BaseSentence
 	Latitude  LatLong // Latitude
 	Longitude LatLong // Longitude
 	Time      Time    // Time Stamp
@@ -20,13 +20,13 @@ type GPGLL struct {
 }
 
 // NewGPGLL constructor
-func NewGPGLL(s Sent) (GPGLL, error) {
+func NewGPGLL(s BaseSentence) (GPGLL, error) {
 	p := newParser(s, PrefixGPGLL)
 	return GPGLL{
-		Sent:      s,
-		Latitude:  p.LatLong(0, 1, "latitude"),
-		Longitude: p.LatLong(2, 3, "longitude"),
-		Time:      p.Time(4, "time"),
-		Validity:  p.EnumString(5, "validity", ValidGLL, InvalidGLL),
+		BaseSentence: s,
+		Latitude:     p.LatLong(0, 1, "latitude"),
+		Longitude:    p.LatLong(2, 3, "longitude"),
+		Time:         p.Time(4, "time"),
+		Validity:     p.EnumString(5, "validity", ValidGLL, InvalidGLL),
 	}, p.Err()
 }

--- a/gpgll_test.go
+++ b/gpgll_test.go
@@ -45,7 +45,7 @@ func TestGPGLL(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gpgll := m.(GPGLL)
-				gpgll.Sent = Sent{}
+				gpgll.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gpgll)
 			}
 		})

--- a/gpgsa.go
+++ b/gpgsa.go
@@ -18,7 +18,7 @@ const (
 // GPGSA represents overview satellite data.
 // http://aprs.gids.nl/nmea/#gsa
 type GPGSA struct {
-	Sent
+	BaseSentence
 	Mode    string   // The selection mode.
 	FixType string   // The fix type.
 	SV      []string // List of satellite PRNs used for this fix.
@@ -28,12 +28,12 @@ type GPGSA struct {
 }
 
 // NewGPGSA parses the GPGSA sentence into this struct.
-func NewGPGSA(s Sent) (GPGSA, error) {
+func NewGPGSA(s BaseSentence) (GPGSA, error) {
 	p := newParser(s, PrefixGPGSA)
 	m := GPGSA{
-		Sent:    s,
-		Mode:    p.EnumString(0, "selection mode", Auto, Manual),
-		FixType: p.EnumString(1, "fix type", FixNone, Fix2D, Fix3D),
+		BaseSentence: s,
+		Mode:         p.EnumString(0, "selection mode", Auto, Manual),
+		FixType:      p.EnumString(1, "fix type", FixNone, Fix2D, Fix3D),
 	}
 	// Satellites in view.
 	for i := 2; i < 14; i++ {

--- a/gpgsa_test.go
+++ b/gpgsa_test.go
@@ -46,7 +46,7 @@ func TestGPGSA(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gpgsa := m.(GPGSA)
-				gpgsa.Sent = Sent{}
+				gpgsa.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gpgsa)
 			}
 		})

--- a/gpgsv.go
+++ b/gpgsv.go
@@ -8,7 +8,7 @@ const (
 // GPGSV represents the GPS Satellites in view
 // http://aprs.gids.nl/nmea/#gpgsv
 type GPGSV struct {
-	Sent
+	BaseSentence
 	TotalMessages   int64       // Total number of messages of this type in this cycle
 	MessageNumber   int64       // Message number
 	NumberSVsInView int64       // Total number of SVs in view
@@ -24,10 +24,10 @@ type GPGSVInfo struct {
 }
 
 // NewGPGSV constructor
-func NewGPGSV(s Sent) (GPGSV, error) {
+func NewGPGSV(s BaseSentence) (GPGSV, error) {
 	p := newParser(s, PrefixGPGSV)
 	m := GPGSV{
-		Sent:            s,
+		BaseSentence:    s,
 		TotalMessages:   p.Int64(0, "total number of messages"),
 		MessageNumber:   p.Int64(1, "message number"),
 		NumberSVsInView: p.Int64(2, "number of SVs in view"),

--- a/gpgsv_test.go
+++ b/gpgsv_test.go
@@ -88,7 +88,7 @@ func TestGPGSV(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gpgsv := m.(GPGSV)
-				gpgsv.Sent = Sent{}
+				gpgsv.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gpgsv)
 			}
 		})

--- a/gprmc.go
+++ b/gprmc.go
@@ -12,7 +12,7 @@ const (
 // GPRMC is the Recommended Minimum Specific GNSS data.
 // http://aprs.gids.nl/nmea/#rmc
 type GPRMC struct {
-	Sent
+	BaseSentence
 	Time      Time    // Time Stamp
 	Validity  string  // validity - A-ok, V-invalid
 	Latitude  LatLong // Latitude
@@ -24,18 +24,18 @@ type GPRMC struct {
 }
 
 // NewGPRMC constructor
-func NewGPRMC(s Sent) (GPRMC, error) {
+func NewGPRMC(s BaseSentence) (GPRMC, error) {
 	p := newParser(s, PrefixGPRMC)
 	m := GPRMC{
-		Sent:      s,
-		Time:      p.Time(0, "time"),
-		Validity:  p.EnumString(1, "validity", ValidRMC, InvalidRMC),
-		Latitude:  p.LatLong(2, 3, "latitude"),
-		Longitude: p.LatLong(4, 5, "longitude"),
-		Speed:     p.Float64(6, "speed"),
-		Course:    p.Float64(7, "course"),
-		Date:      p.Date(8, "date"),
-		Variation: p.Float64(9, "variation"),
+		BaseSentence: s,
+		Time:         p.Time(0, "time"),
+		Validity:     p.EnumString(1, "validity", ValidRMC, InvalidRMC),
+		Latitude:     p.LatLong(2, 3, "latitude"),
+		Longitude:    p.LatLong(4, 5, "longitude"),
+		Speed:        p.Float64(6, "speed"),
+		Course:       p.Float64(7, "course"),
+		Date:         p.Date(8, "date"),
+		Variation:    p.Float64(9, "variation"),
 	}
 	if p.EnumString(10, "variation", West, East) == West {
 		m.Variation = 0 - m.Variation

--- a/gprmc_test.go
+++ b/gprmc_test.go
@@ -57,7 +57,7 @@ func TestGPRMC(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gprmc := m.(GPRMC)
-				gprmc.Sent = Sent{}
+				gprmc.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gprmc)
 			}
 		})

--- a/gpvtg.go
+++ b/gpvtg.go
@@ -8,7 +8,7 @@ const (
 // GPVTG represents track & speed data.
 // http://aprs.gids.nl/nmea/#vtg
 type GPVTG struct {
-	Sent
+	BaseSentence
 	TrueTrack        float64
 	MagneticTrack    float64
 	GroundSpeedKnots float64
@@ -17,10 +17,10 @@ type GPVTG struct {
 
 // NewGPVTG parses the GPVTG sentence into this struct.
 // e.g: $GPVTG,360.0,T,348.7,M,000.0,N,000.0,K*43
-func NewGPVTG(s Sent) (GPVTG, error) {
+func NewGPVTG(s BaseSentence) (GPVTG, error) {
 	p := newParser(s, PrefixGPVTG)
 	return GPVTG{
-		Sent:             s,
+		BaseSentence:     s,
 		TrueTrack:        p.Float64(0, "true track"),
 		MagneticTrack:    p.Float64(2, "magnetic track"),
 		GroundSpeedKnots: p.Float64(4, "ground speed (knots)"),

--- a/gpvtg_test.go
+++ b/gpvtg_test.go
@@ -39,7 +39,7 @@ func TestGPVTG(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gpvtg := m.(GPVTG)
-				gpvtg.Sent = Sent{}
+				gpvtg.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gpvtg)
 			}
 		})

--- a/gpzda.go
+++ b/gpzda.go
@@ -8,7 +8,7 @@ const (
 // GPZDA represents date & time data.
 // http://aprs.gids.nl/nmea/#zda
 type GPZDA struct {
-	Sent
+	BaseSentence
 	Time          Time
 	Day           int64
 	Month         int64
@@ -18,10 +18,10 @@ type GPZDA struct {
 }
 
 // NewGPZDA constructor
-func NewGPZDA(s Sent) (GPZDA, error) {
+func NewGPZDA(s BaseSentence) (GPZDA, error) {
 	p := newParser(s, PrefixGPZDA)
 	return GPZDA{
-		Sent:          s,
+		BaseSentence:  s,
 		Time:          p.Time(0, "time"),
 		Day:           p.Int64(1, "day"),
 		Month:         p.Int64(2, "month"),

--- a/gpzda_test.go
+++ b/gpzda_test.go
@@ -47,7 +47,7 @@ func TestGPZDA(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				gpzda := m.(GPZDA)
-				gpzda.Sent = Sent{}
+				gpzda.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, gpzda)
 			}
 		})

--- a/parser.go
+++ b/parser.go
@@ -8,14 +8,14 @@ import (
 // parser provides a simple way of accessing and parsing
 // sentence fields
 type parser struct {
-	Sent
+	BaseSentence
 	prefix string
 	err    error
 }
 
 // newParser constructor
-func newParser(s Sent, prefix string) *parser {
-	p := &parser{Sent: s, prefix: prefix}
+func newParser(s BaseSentence, prefix string) *parser {
+	p := &parser{BaseSentence: s, prefix: prefix}
 	if p.Type != prefix {
 		p.SetErr("prefix", p.Type)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -211,7 +211,7 @@ var parsertests = []struct {
 func TestParser(t *testing.T) {
 	for _, tt := range parsertests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newParser(Sent{
+			p := newParser(BaseSentence{
 				Type:   "type",
 				Fields: tt.fields,
 			}, "type")

--- a/pgrme.go
+++ b/pgrme.go
@@ -10,14 +10,14 @@ const (
 // PGRME is Estimated Position Error (Garmin proprietary sentence)
 // http://aprs.gids.nl/nmea/#rme
 type PGRME struct {
-	Sent
+	BaseSentence
 	Horizontal float64 // Estimated horizontal position error (HPE) in metres
 	Vertical   float64 // Estimated vertical position error (VPE) in metres
 	Spherical  float64 // Overall spherical equivalent position error in meters
 }
 
 // NewPGRME constructor
-func NewPGRME(s Sent) (PGRME, error) {
+func NewPGRME(s BaseSentence) (PGRME, error) {
 	p := newParser(s, PrefixPGRME)
 
 	horizontal := p.Float64(0, "horizontal error")
@@ -30,9 +30,9 @@ func NewPGRME(s Sent) (PGRME, error) {
 	_ = p.EnumString(5, "spherical error unit", ErrorUnit)
 
 	return PGRME{
-		Sent:       s,
-		Horizontal: horizontal,
-		Vertical:   vertial,
-		Spherical:  spherical,
+		BaseSentence: s,
+		Horizontal:   horizontal,
+		Vertical:     vertial,
+		Spherical:    spherical,
 	}, p.Err()
 }

--- a/pgrme_test.go
+++ b/pgrme_test.go
@@ -58,7 +58,7 @@ func TestPGRME(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				pgrme := m.(PGRME)
-				pgrme.Sent = Sent{}
+				pgrme.BaseSentence = BaseSentence{}
 				assert.Equal(t, tt.msg, pgrme)
 			}
 		})

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -10,12 +10,12 @@ var sentencetests = []struct {
 	name string
 	raw  string
 	err  string
-	sent Sent
+	sent BaseSentence
 }{
 	{
 		name: "checksum ok",
 		raw:  "$GPFOO,1,2,3.3,x,y,zz,*51",
-		sent: Sent{
+		sent: BaseSentence{
 			Type:     "GPFOO",
 			Fields:   []string{"1", "2", "3.3", "x", "y", "zz", ""},
 			Checksum: "51",
@@ -25,7 +25,7 @@ var sentencetests = []struct {
 	{
 		name: "good parsing",
 		raw:  "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-		sent: Sent{
+		sent: BaseSentence{
 			Type:     "GPRMC",
 			Fields:   []string{"235236", "A", "3925.9479", "N", "11945.9211", "W", "44.7", "153.6", "250905", "15.2", "E", "A"},
 			Checksum: "0C",
@@ -79,13 +79,12 @@ func TestSentences(t *testing.T) {
 }
 
 func TestSentenceMethods(t *testing.T) {
-	sent := Sent{
+	sent := BaseSentence{
 		Type: "type",
 		Raw:  "raw",
 	}
 	assert.Equal(t, "type", sent.Prefix())
 	assert.Equal(t, "raw", sent.String())
-	assert.Equal(t, sent, sent.Sentence())
 	assert.NoError(t, sent.Validate())
 }
 


### PR DESCRIPTION
- Rename `Message` interface to `Sentence`
- Rename `Sent` struct to `BaseSentence`
- Delete `Sentence()` method