### PR TITLE
Functions for talker and message type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,20 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	m := s.(nmea.RMC)
-	fmt.Printf("Raw sentence: %v\n", m)
-	fmt.Printf("Time: %s\n", m.Time)
-	fmt.Printf("Validity: %s\n", m.Validity)
-	fmt.Printf("Latitude GPS: %s\n", nmea.FormatGPS(m.Latitude))
-	fmt.Printf("Latitude DMS: %s\n", nmea.FormatDMS(m.Latitude))
-	fmt.Printf("Longitude GPS: %s\n", nmea.FormatGPS(m.Longitude))
-	fmt.Printf("Longitude DMS: %s\n", nmea.FormatDMS(m.Longitude))
-	fmt.Printf("Speed: %f\n", m.Speed)
-	fmt.Printf("Course: %f\n", m.Course)
-	fmt.Printf("Date: %s\n", m.Date)
-	fmt.Printf("Variation: %f\n", m.Variation)
+	if s.DataType() == nmea.TypeRMC {
+		m := s.(nmea.RMC)
+		fmt.Printf("Raw sentence: %v\n", m)
+		fmt.Printf("Time: %s\n", m.Time)
+		fmt.Printf("Validity: %s\n", m.Validity)
+		fmt.Printf("Latitude GPS: %s\n", nmea.FormatGPS(m.Latitude))
+		fmt.Printf("Latitude DMS: %s\n", nmea.FormatDMS(m.Latitude))
+		fmt.Printf("Longitude GPS: %s\n", nmea.FormatGPS(m.Longitude))
+		fmt.Printf("Longitude DMS: %s\n", nmea.FormatDMS(m.Longitude))
+		fmt.Printf("Speed: %f\n", m.Speed)
+		fmt.Printf("Course: %f\n", m.Course)
+		fmt.Printf("Date: %s\n", m.Date)
+		fmt.Printf("Variation: %f\n", m.Variation)
+	}
 }
 ```
 

--- a/sentence.go
+++ b/sentence.go
@@ -20,6 +20,7 @@ const (
 type Sentence interface {
 	fmt.Stringer
 	Prefix() string
+	MessageType() string
 }
 
 // BaseSentence contains the information about the NMEA sentence
@@ -31,9 +32,14 @@ type BaseSentence struct {
 	Raw      string   // The raw NMEA sentence received
 }
 
-// Prefix returns the type of the message
+// Prefix returns the talker and type of message
 func (s BaseSentence) Prefix() string {
 	return s.Talker + s.Type
+}
+
+// MessageType returns the type of the message
+func (s BaseSentence) MessageType() string {
+	return s.Type
 }
 
 // String formats the sentence into a string

--- a/sentence.go
+++ b/sentence.go
@@ -21,6 +21,7 @@ type Sentence interface {
 	fmt.Stringer
 	Prefix() string
 	MessageType() string
+	MessageTalker() string
 }
 
 // BaseSentence contains the information about the NMEA sentence
@@ -40,6 +41,11 @@ func (s BaseSentence) Prefix() string {
 // MessageType returns the type of the message
 func (s BaseSentence) MessageType() string {
 	return s.Type
+}
+
+// MessageTalker returns the talker of the message
+func (s BaseSentence) MessageTalker() string {
+	return s.Talker
 }
 
 // String formats the sentence into a string

--- a/sentence.go
+++ b/sentence.go
@@ -20,8 +20,8 @@ const (
 type Sentence interface {
 	fmt.Stringer
 	Prefix() string
-	MessageType() string
-	MessageTalker() string
+	DataType() string
+	TalkerID() string
 }
 
 // BaseSentence contains the information about the NMEA sentence
@@ -38,13 +38,13 @@ func (s BaseSentence) Prefix() string {
 	return s.Talker + s.Type
 }
 
-// MessageType returns the type of the message
-func (s BaseSentence) MessageType() string {
+// DataType returns the type of the message
+func (s BaseSentence) DataType() string {
 	return s.Type
 }
 
-// MessageTalker returns the talker of the message
-func (s BaseSentence) MessageTalker() string {
+// TalkerID returns the talker of the message
+func (s BaseSentence) TalkerID() string {
 	return s.Talker
 }
 

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -7,18 +7,18 @@ import (
 )
 
 var sentencetests = []struct {
-	name      string
-	raw       string
-	msgtype   string
-	msgtalker string
-	err       string
-	sent      BaseSentence
+	name     string
+	raw      string
+	datatype string
+	talkerid string
+	err      string
+	sent     BaseSentence
 }{
 	{
-		name:      "checksum ok",
-		raw:       "$GPFOO,1,2,3.3,x,y,zz,*51",
-		msgtype:   "FOO",
-		msgtalker: "GP",
+		name:     "checksum ok",
+		raw:      "$GPFOO,1,2,3.3,x,y,zz,*51",
+		datatype: "FOO",
+		talkerid: "GP",
 		sent: BaseSentence{
 			Talker:   "GP",
 			Type:     "FOO",
@@ -28,10 +28,10 @@ var sentencetests = []struct {
 		},
 	},
 	{
-		name:      "good parsing",
-		raw:       "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-		msgtype:   "RMC",
-		msgtalker: "GP",
+		name:     "good parsing",
+		raw:      "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
+		datatype: "RMC",
+		talkerid: "GP",
 		sent: BaseSentence{
 			Talker:   "GP",
 			Type:     "RMC",
@@ -82,8 +82,8 @@ func TestSentences(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.sent, sent)
 				assert.Equal(t, tt.sent.Raw, sent.String())
-				assert.Equal(t, tt.msgtype, sent.MessageType())
-				assert.Equal(t, tt.msgtalker, sent.MessageTalker())
+				assert.Equal(t, tt.datatype, sent.DataType())
+				assert.Equal(t, tt.talkerid, sent.TalkerID())
 			}
 		})
 	}

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -11,6 +11,7 @@ var sentencetests = []struct {
 	raw      string
 	datatype string
 	talkerid string
+	prefix   string
 	err      string
 	sent     BaseSentence
 }{
@@ -19,6 +20,7 @@ var sentencetests = []struct {
 		raw:      "$GPFOO,1,2,3.3,x,y,zz,*51",
 		datatype: "FOO",
 		talkerid: "GP",
+		prefix:   "GPFOO",
 		sent: BaseSentence{
 			Talker:   "GP",
 			Type:     "FOO",
@@ -32,6 +34,7 @@ var sentencetests = []struct {
 		raw:      "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
 		datatype: "RMC",
 		talkerid: "GP",
+		prefix:   "GPRMC",
 		sent: BaseSentence{
 			Talker:   "GP",
 			Type:     "RMC",
@@ -84,6 +87,7 @@ func TestSentences(t *testing.T) {
 				assert.Equal(t, tt.sent.Raw, sent.String())
 				assert.Equal(t, tt.datatype, sent.DataType())
 				assert.Equal(t, tt.talkerid, sent.TalkerID())
+				assert.Equal(t, tt.prefix, sent.Prefix())
 			}
 		})
 	}

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -7,14 +7,18 @@ import (
 )
 
 var sentencetests = []struct {
-	name string
-	raw  string
-	err  string
-	sent BaseSentence
+	name      string
+	raw       string
+	msgtype   string
+	msgtalker string
+	err       string
+	sent      BaseSentence
 }{
 	{
-		name: "checksum ok",
-		raw:  "$GPFOO,1,2,3.3,x,y,zz,*51",
+		name:      "checksum ok",
+		raw:       "$GPFOO,1,2,3.3,x,y,zz,*51",
+		msgtype:   "FOO",
+		msgtalker: "GP",
 		sent: BaseSentence{
 			Talker:   "GP",
 			Type:     "FOO",
@@ -24,8 +28,10 @@ var sentencetests = []struct {
 		},
 	},
 	{
-		name: "good parsing",
-		raw:  "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
+		name:      "good parsing",
+		raw:       "$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
+		msgtype:   "RMC",
+		msgtalker: "GP",
 		sent: BaseSentence{
 			Talker:   "GP",
 			Type:     "RMC",
@@ -76,6 +82,8 @@ func TestSentences(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.sent, sent)
 				assert.Equal(t, tt.sent.Raw, sent.String())
+				assert.Equal(t, tt.msgtype, sent.MessageType())
+				assert.Equal(t, tt.msgtalker, sent.MessageTalker())
 			}
 		})
 	}


### PR DESCRIPTION
To make it easier to use sentences where the talker is unknown, I've added functions to retrieve the talker and message type separately.  
This gives the opportunity to case switch the type of message, which e.g. would be nice to have when receiving $GNGGA and $GPGGA simultaneously.