### PR TITLE
Implement support for VDM/VDO encapsulated binary messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ At this moment, this library supports the following sentence types:
 - [GNS](https://www.trimble.com/oem_receiverhelp/v4.44/en/NMEA-0183messages_GNS.html) - Combined GPS fix for GPS, Glonass, Galileo, and BeiDou
 - [PGRME](http://aprs.gids.nl/nmea/#rme) - Estimated Position Error (Garmin proprietary sentence)
 - [THS](http://www.nuovamarea.net/pytheas_9.html) - Actual vessel heading in degrees True and status
+- [VDM/VDO](http://catb.org/gpsd/AIVDM.html) - Encapsulated binary payload
 
 ## Example
 

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -51,7 +51,7 @@ var sentencetests = []struct {
 	{
 		name: "bad start character",
 		raw:  "%GPFOO,1,2,3,x,y,z*1A",
-		err:  "nmea: sentence does not start with a '$'",
+		err:  "nmea: sentence does not start with a '$' or '!'",
 	},
 	{
 		name: "bad checksum delimiter",
@@ -61,12 +61,12 @@ var sentencetests = []struct {
 	{
 		name: "no start delimiter",
 		raw:  "abc$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-		err:  "nmea: sentence does not start with a '$'",
+		err:  "nmea: sentence does not start with a '$' or '!'",
 	},
 	{
 		name: "no contain delimiter",
 		raw:  "GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
-		err:  "nmea: sentence does not start with a '$'",
+		err:  "nmea: sentence does not start with a '$' or '!'",
 	},
 	{
 		name: "another bad checksum",
@@ -150,11 +150,16 @@ var parsetests = []struct {
 	{
 		name: "bad sentence",
 		raw:  "SDFSD,2340dfmswd",
-		err:  "nmea: sentence does not start with a '$'",
+		err:  "nmea: sentence does not start with a '$' or '!'",
 	},
 	{
 		name: "bad sentence type",
 		raw:  "$INVALID,123,123,*7D",
+		err:  "nmea: sentence prefix 'INVALID' not supported",
+	},
+	{
+		name: "bad encapsulated sentence type",
+		raw:  "!INVALID,1,2,*7E",
 		err:  "nmea: sentence prefix 'INVALID' not supported",
 	},
 }

--- a/vdmvdo.go
+++ b/vdmvdo.go
@@ -1,0 +1,76 @@
+package nmea
+
+const (
+	// TypeVDM type for VDM sentences
+	TypeVDM = "VDM"
+
+	// TypeVDO type for VDO sentences
+	TypeVDO = "VDO"
+)
+
+// VDMVDO is a format used to encapsulate generic binary payloads. It is most commonly used
+// with AIS data.
+// http://catb.org/gpsd/AIVDM.html
+type VDMVDO struct {
+	BaseSentence
+	NumFragments   int64
+	FragmentNumber int64
+	MessageID      int64
+	Channel        string
+	Payload        []byte
+}
+
+// SixBitASCIIArmour decodes the 6-bit ascii armor used for VDM and VDO messages
+func (p *parser) SixBitASCIIArmour(i int, fillBits int) []byte {
+	if fillBits < 0 || fillBits >= 6 {
+		return nil
+	}
+
+	payload := []byte(p.String(i, "encoded payload"))
+	numBits := len(payload)*6 - fillBits
+
+	if numBits < 0 {
+		return nil
+	}
+
+	result := make([]byte, numBits)
+	resultIndex := 0
+
+	for _, v := range payload {
+		if v < 48 || v >= 120 {
+			return nil
+		}
+
+		d := v - 48
+		if d > 40 {
+			d -= 8
+		}
+
+		for i := 5; i >= 0 && resultIndex < len(result); i-- {
+			result[resultIndex] = (d >> uint(i)) & 1
+			resultIndex++
+		}
+	}
+
+	return result
+}
+
+// newVDMVDO constructor
+func newVDMVDO(s BaseSentence) (VDMVDO, error) {
+	p := newParser(s)
+
+	m := VDMVDO{
+		BaseSentence:   s,
+		NumFragments:   p.Int64(0, "number of fragments"),
+		FragmentNumber: p.Int64(1, "fragment number"),
+		MessageID:      p.Int64(2, "sequence number"),
+		Channel:        p.String(3, "channel ID"),
+		Payload:        p.SixBitASCIIArmour(4, int(p.Int64(5, "number of padding bits"))),
+	}
+
+	if m.Payload == nil {
+		p.SetErr("payload", "Decode failed")
+	}
+
+	return m, p.Err()
+}

--- a/vdmvdo_test.go
+++ b/vdmvdo_test.go
@@ -1,0 +1,97 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var vdmtests = []struct {
+	name string
+	raw  string
+	err  string
+	msg  VDMVDO
+}{
+	{
+		name: "Good single fragment message",
+		raw:  "!AIVDM,1,1,,A,13aGt0PP0jPN@9fMPKVDJgwfR>`<,0*55",
+		msg: VDMVDO{
+			NumFragments:   1,
+			FragmentNumber: 1,
+			MessageID:      0,
+			Channel:        "A",
+			Payload:        []byte{0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0},
+		},
+	},
+	{
+		name: "Good single fragment message with padding",
+		raw:  "!AIVDM,1,1,,A,H77nSfPh4U=<E`H4U8G;:222220,2*1F",
+		msg: VDMVDO{
+			NumFragments:   1,
+			FragmentNumber: 1,
+			MessageID:      0,
+			Channel:        "A",
+			Payload:        []byte{0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0},
+		},
+	},
+	{
+		name: "Good multipart fragment",
+		raw:  "!AIVDM,2,2,4,B,00000000000,2*23",
+		msg: VDMVDO{
+			NumFragments:   2,
+			FragmentNumber: 2,
+			MessageID:      4,
+			Channel:        "B",
+			Payload:        []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	},
+	{
+		name: "Empty payload",
+		raw:  "!AIVDM,1,1,,1,,0*56",
+		msg: VDMVDO{
+			NumFragments:   1,
+			FragmentNumber: 1,
+			MessageID:      0,
+			Channel:        "1",
+			Payload:        []byte{},
+		},
+	},
+	{
+		name: "Invalid symbol in payload",
+		raw:  "!AIVDM,1,1,,1,000 00,0*46",
+		err:  "nmea: AIVDM invalid payload: Decode failed",
+	},
+	{
+		name: "Negative number of fill bits",
+		raw:  "!AIVDM,1,1,,1,000,-3*48",
+		err:  "nmea: AIVDM invalid payload: Decode failed",
+	},
+	{
+		name: "Too high number of fill bits",
+		raw:  "!AIVDO,1,1,,1,000,20*56",
+		err:  "nmea: AIVDO invalid payload: Decode failed",
+	},
+	{
+		name: "Negative number of bits",
+		raw:  "!AIVDM,1,1,,1,,2*54",
+		err:  "nmea: AIVDM invalid payload: Decode failed",
+	},
+}
+
+func TestVDM(t *testing.T) {
+	for _, tt := range vdmtests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Parse(tt.raw)
+
+			if tt.err != "" {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				vdm := m.(VDMVDO)
+				vdm.BaseSentence = BaseSentence{}
+				assert.Equal(t, tt.msg, vdm)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hello,

This pull request implements support for VDM/VDO encapsulated message parsing. It requires a change to sentence.go as these messages use '!' instead of '$' as start byte.

VDM and VDO are the same message, depending on the circumstances or configuration the sender will produce one or the other, but they are handled identically. Currently I made one decoder that handles both messages, is this the way to go?

Sincerely,
Bertold