### PR TITLE
Add GSensord - not sure how to deal with checksums being optional

### DIFF
--- a/gsensord.go
+++ b/gsensord.go
@@ -1,0 +1,28 @@
+package nmea
+
+const (
+	// TypeGSensord type for GSensord sentences
+	TypeGSensord = "GSENSORD"
+)
+
+// GSensord represents measured g-loadings in the x, y and z axis.
+// http://aprs.gids.nl/nmea/#gsa
+type GSensord struct {
+	BaseSentence
+	X float64 // X-axis G value
+	Y float64 // Y-axis G value
+	Z float64 // Z-axis G valye
+}
+
+// newGSensord parses the GSensord sentence into this struct.
+func newGSensord(s BaseSentence) (GSensord, error) {
+	p := newParser(s)
+	p.AssertType(TypeGSensord)
+	m := GSensord{
+		BaseSentence: s,
+		X:            p.Float64(0, "x-axis g value"),
+		Y:            p.Float64(1, "y-axis g value"),
+		Z:            p.Float64(2, "z-axis g value"),
+	}
+	return m, p.Err()
+}

--- a/gsensord_test.go
+++ b/gsensord_test.go
@@ -1,0 +1,41 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var gsensoredtests = []struct {
+	name string
+	raw  string
+	err  string
+	msg  GSensord
+}{
+	{
+		name: "good sentence",
+		raw:  "$GSENSORD,0.060,0.060,-0.180",
+		msg: GSensord{
+			X: 0.06,
+			Y: 0.06,
+			Z: -0.180,
+		},
+	},
+}
+
+func TestGSensord(t *testing.T) {
+	for _, tt := range gsensoredtests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Parse(tt.raw)
+			if tt.err != "" {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				gsensored := m.(GSensord)
+				gsensored.BaseSentence = BaseSentence{}
+				assert.Equal(t, tt.msg, gsensored)
+			}
+		})
+	}
+}

--- a/sentence.go
+++ b/sentence.go
@@ -1,6 +1,7 @@
 package nmea
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -68,9 +69,9 @@ func parseSentence(raw string) (BaseSentence, error) {
 
 	if len(splice) == 2 {
 		checksumRaw = strings.ToUpper(splice[1])
-	}
-
-	if checksumRaw != "" {
+		if checksumRaw == "" {
+			return BaseSentence{}, errors.New("nmea: sentence does not contain checksum")
+		}
 		checksum := xorChecksum(fieldsRaw)
 
 		// Validate the checksum
@@ -93,7 +94,7 @@ func parseSentence(raw string) (BaseSentence, error) {
 // parsePrefix takes the first field and splits it into a talker id and data type.
 func parsePrefix(s string) (string, string) {
 	if s == TypeGSensord {
-		return "S", s
+		return "P", s
 	}
 	if strings.HasPrefix(s, "P") {
 		return "P", s[1:]

--- a/sentence.go
+++ b/sentence.go
@@ -94,7 +94,7 @@ func parseSentence(raw string) (BaseSentence, error) {
 // parsePrefix takes the first field and splits it into a talker id and data type.
 func parsePrefix(s string) (string, string) {
 	if s == TypeGSensord {
-		return "P", s
+		return "", s
 	}
 	if strings.HasPrefix(s, "P") {
 		return "P", s[1:]

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -54,6 +54,11 @@ var sentencetests = []struct {
 		err:  "nmea: sentence does not start with a '$' or '!'",
 	},
 	{
+		name: "bad checksum delimiter",
+		raw:  "$GPFOO,1,2,3,x,y,z*",
+		err:  "nmea: sentence does not contain checksum",
+	},
+	{
 		name: "no start delimiter",
 		raw:  "abc$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
 		err:  "nmea: sentence does not start with a '$' or '!'",

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -54,11 +54,6 @@ var sentencetests = []struct {
 		err:  "nmea: sentence does not start with a '$' or '!'",
 	},
 	{
-		name: "bad checksum delimiter",
-		raw:  "$GPFOO,1,2,3,x,y,z",
-		err:  "nmea: sentence does not contain checksum separator",
-	},
-	{
 		name: "no start delimiter",
 		raw:  "abc$GPRMC,235236,A,3925.9479,N,11945.9211,W,44.7,153.6,250905,15.2,E,A*0C",
 		err:  "nmea: sentence does not start with a '$' or '!'",


### PR DESCRIPTION
NB: I don't actually expect you to merge this request, I've broken the handling of missing checksums.

I also think this might be a specific usecase and not a standards type issue.

Basically the Navman MIVUE dashcams add a $GSENSORD sentence that doesn't have checksums.

I did consider refactoring to make types checksum aware so they can complain if they're expecting a checksum or not, but I wasn't sure how you'd like to proceed.

Probably best to just leave it out entirely, or have an unexpected type handler, but then I could just do that with a substring match before parsing.

Sample data:

```
$GSENSORD,0.060,0.120,-0.180
$GPRMC,073815.000,A,2703.7507,S,15257.3940,E,30.35,36.48,060419,,,A*74
$GPGGA,073815.000,2703.7507,S,15257.3940,E,1,12,0.8,8.4,M,39.6,M,,0000*4B
$GPGSA,A,3,22,31,03,01,193,26,194,18,23,16,14,11,1.6,0.8,1.4*31
$GPGSV,4,1,16,01,44,297,37,03,55,211,28,09,01,263,,11,19,310,22*7C
$GPGSV,4,2,16,14,22,118,27,16,27,032,40,18,33,331,30,22,80,195,37*7D
$GPGSV,4,3,16,23,28,245,32,26,40,065,42,31,42,142,40,32,25,248,*7A
$GPGSV,4,4,16,42,57,343,29,193,78,210,24,194,39,337,36,195,15,346,27*4D
$GSENSORD,-0.120,0.120,-0.250
$GPRMC,073816.000,A,2703.7438,S,15257.3995,E,30.42,35.62,060419,,,A*79
$GPGGA,073816.000,2703.7438,S,15257.3995,E,1,12,0.8,8.4,M,39.6,M,,0000*4D
$GPGSA,A,3,22,31,03,01,193,26,194,18,23,16,14,11,1.6,0.8,1.4*31
$GPGSV,4,1,16,01,44,297,37,03,55,211,27,09,01,263,,11,19,310,21*70
$GPGSV,4,2,16,14,22,118,25,16,27,032,39,18,33,331,31,22,80,195,37*70
$GPGSV,4,3,16,23,28,245,33,26,40,065,43,31,42,142,29,32,25,248,*75
$GPGSV,4,4,16,42,57,343,30,193,78,210,24,194,39,337,36,195,15,346,29*4B
```