### PR TITLE
Add support for WPL and RTE sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ At this moment, this library supports the following sentence types:
 - [PGRME](http://aprs.gids.nl/nmea/#rme) - Estimated Position Error (Garmin proprietary sentence)
 - [THS](http://www.nuovamarea.net/pytheas_9.html) - Actual vessel heading in degrees True and status
 - [VDM/VDO](http://catb.org/gpsd/AIVDM.html) - Encapsulated binary payload
+- [WPL](http://aprs.gids.nl/nmea/#wpl) - Waypoint location
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ At this moment, this library supports the following sentence types:
 - [THS](http://www.nuovamarea.net/pytheas_9.html) - Actual vessel heading in degrees True and status
 - [VDM/VDO](http://catb.org/gpsd/AIVDM.html) - Encapsulated binary payload
 - [WPL](http://aprs.gids.nl/nmea/#wpl) - Waypoint location
+- [RTE](http://aprs.gids.nl/nmea/#rte) - Route
 
 ## Example
 

--- a/parser.go
+++ b/parser.go
@@ -55,12 +55,11 @@ func (p *parser) ListString(from int, context string) (list []string) {
 	if p.err != nil {
 		return []string{}
 	}
-	fields := p.Fields[from:]
-	if len(fields) == 0 {
-		p.SetErr(context, "list can not be empty")
+	if from < 0 || from >= len(p.Fields) {
+		p.SetErr(context, "index out of range")
 		return []string{}
 	}
-	return append(list, fields...)
+	return append(list, p.Fields[from:]...)
 }
 
 // EnumString returns the field value at the specified index.

--- a/parser.go
+++ b/parser.go
@@ -49,6 +49,20 @@ func (p *parser) String(i int, context string) string {
 	return p.Fields[i]
 }
 
+// ListString returns a list of all fields from the given start index.
+// An error occurs if there is no fields after the given start index.
+func (p *parser) ListString(from int, context string) (list []string) {
+	if p.err != nil {
+		return list
+	}
+	fields := p.Fields[from:]
+	if len(fields) == 0 {
+		p.SetErr(context, "list can not be empty")
+		return list
+	}
+	return append(list, fields...)
+}
+
 // EnumString returns the field value at the specified index.
 // An error occurs if the value is not one of the options and not empty.
 func (p *parser) EnumString(i int, context string, options ...string) string {

--- a/parser.go
+++ b/parser.go
@@ -53,12 +53,12 @@ func (p *parser) String(i int, context string) string {
 // An error occurs if there is no fields after the given start index.
 func (p *parser) ListString(from int, context string) (list []string) {
 	if p.err != nil {
-		return list
+		return []string{}
 	}
 	fields := p.Fields[from:]
 	if len(fields) == 0 {
 		p.SetErr(context, "list can not be empty")
-		return list
+		return []string{}
 	}
 	return append(list, fields...)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -40,6 +40,23 @@ var parsertests = []struct {
 		},
 	},
 	{
+		name:     "ListString",
+		fields:   []string{"wot", "foo", "bar"},
+		expected: []string{"foo", "bar"},
+		parse: func(p *parser) interface{} {
+			return p.ListString(1, "thing")
+		},
+	},
+	{
+		name:     "ListString is empty",
+		fields:   []string{"wot"},
+		expected: []string{},
+		hasErr:   true,
+		parse: func(p *parser) interface{} {
+			return p.ListString(1, "thing")
+		},
+	},
+	{
 		name:     "String with existing error",
 		expected: "",
 		hasErr:   true,

--- a/parser_test.go
+++ b/parser_test.go
@@ -48,12 +48,12 @@ var parsertests = []struct {
 		},
 	},
 	{
-		name:     "ListString is empty",
+		name:     "ListString out of range",
 		fields:   []string{"wot"},
 		expected: []string{},
 		hasErr:   true,
 		parse: func(p *parser) interface{} {
-			return p.ListString(1, "thing")
+			return p.ListString(10, "thing")
 		},
 	},
 	{

--- a/rte.go
+++ b/rte.go
@@ -1,0 +1,36 @@
+package nmea
+
+const (
+	// TypeRTE type for RTE sentences
+	TypeRTE = "RTE"
+
+	// ActiveRoute active route
+	ActiveRoute = "c"
+
+	// WaypointList list containing waypoints
+	WaypointList = "w"
+)
+
+// RTE is a route of waypoints
+type RTE struct {
+	BaseSentence
+	NumberOfSentences         int64    // Number of sentences in sequence
+	SentenceNumber            int64    // Sentence number
+	ActiveRouteOrWaypointList string   // Current active route or waypoint list
+	Name                      string   // Name or number of active route
+	Idents                    []string // List of ident of waypoints
+}
+
+// newRTE constructor
+func newRTE(s BaseSentence) (RTE, error) {
+	p := newParser(s)
+	p.AssertType(TypeRTE)
+	return RTE{
+		BaseSentence:              s,
+		NumberOfSentences:         p.Int64(0, "number of sentences"),
+		SentenceNumber:            p.Int64(1, "sentence number"),
+		ActiveRouteOrWaypointList: p.EnumString(2, "active route or waypoint list", ActiveRoute, WaypointList),
+		Name:                      p.String(3, "name or number"),
+		Idents:                    p.ListString(4, "ident of waypoints"),
+	}, p.Err()
+}

--- a/rte_test.go
+++ b/rte_test.go
@@ -24,9 +24,9 @@ var rtetests = []struct {
 		},
 	},
 	{
-		name: "empty route",
+		name: "index out if range",
 		raw:  "$IIRTE,4,1,c,Rte 1*77",
-		err:  "nmea: IIRTE invalid ident of waypoints: list can not be empty",
+		err:  "nmea: IIRTE invalid ident of waypoints: index out of range",
 	},
 	{
 		name: "invalid number of sentences",

--- a/rte_test.go
+++ b/rte_test.go
@@ -1,0 +1,63 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var rtetests = []struct {
+	name string
+	raw  string
+	err  string
+	msg  RTE
+}{
+	{
+		name: "good sentence",
+		raw:  "$IIRTE,4,1,c,Rte 1,411,412,413,414,415*6F",
+		msg: RTE{
+			NumberOfSentences:         4,
+			SentenceNumber:            1,
+			ActiveRouteOrWaypointList: ActiveRoute,
+			Name:                      "Rte 1",
+			Idents:                    []string{"411", "412", "413", "414", "415"},
+		},
+	},
+	{
+		name: "empty route",
+		raw:  "$IIRTE,4,1,c,Rte 1*77",
+		err:  "nmea: IIRTE invalid ident of waypoints: list can not be empty",
+	},
+	{
+		name: "invalid number of sentences",
+		raw:  "$IIRTE,X,1,c,Rte 1,411,412,413,414,415*03",
+		err:  "nmea: IIRTE invalid number of sentences: X",
+	},
+	{
+		name: "invalid sentence number",
+		raw:  "$IIRTE,4,X,c,Rte 1,411,412,413,414,415*06",
+		err:  "nmea: IIRTE invalid sentence number: X",
+	},
+	{
+		name: "invalid active route or waypoint list",
+		raw:  "$IIRTE,4,1,X,Rte 1,411,412,413,414,415*54",
+		err:  "nmea: IIRTE invalid active route or waypoint list: X",
+	},
+}
+
+func TestRTE(t *testing.T) {
+	for _, tt := range rtetests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Parse(tt.raw)
+			if tt.err != "" {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				rte := m.(RTE)
+				rte.BaseSentence = BaseSentence{}
+				assert.Equal(t, tt.msg, rte)
+			}
+		})
+	}
+}

--- a/sentence.go
+++ b/sentence.go
@@ -136,6 +136,8 @@ func Parse(raw string) (Sentence, error) {
 			return newGNS(s)
 		case TypeTHS:
 			return newTHS(s)
+		case TypeWPL:
+			return newWPL(s)
 		}
 	}
 	if strings.HasPrefix(s.Raw, SentenceStartEncapsulated) {

--- a/sentence.go
+++ b/sentence.go
@@ -138,6 +138,8 @@ func Parse(raw string) (Sentence, error) {
 			return newTHS(s)
 		case TypeWPL:
 			return newWPL(s)
+		case TypeRTE:
+			return newRTE(s)
 		}
 	}
 	if strings.HasPrefix(s.Raw, SentenceStartEncapsulated) {

--- a/wpl.go
+++ b/wpl.go
@@ -1,0 +1,26 @@
+package nmea
+
+const (
+	// TypeWPL type for WPL sentences
+	TypeWPL = "WPL"
+)
+
+// WPL contains information about a waypoint location
+type WPL struct {
+	BaseSentence
+	Latitude  float64 // Latitude
+	Longitude float64 // Longitude
+	Ident     string  // Ident of nth waypoint
+}
+
+// newWPL constructor
+func newWPL(s BaseSentence) (WPL, error) {
+	p := newParser(s)
+	p.AssertType(TypeWPL)
+	return WPL{
+		BaseSentence: s,
+		Latitude:     p.LatLong(0, 1, "latitude"),
+		Longitude:    p.LatLong(2, 3, "longitude"),
+		Ident:        p.String(4, "ident of nth waypoint"),
+	}, p.Err()
+}

--- a/wpl_test.go
+++ b/wpl_test.go
@@ -1,0 +1,70 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var wpltests = []struct {
+	name string
+	raw  string
+	err  string
+	msg  WPL
+}{
+	{
+		name: "good sentence",
+		raw:  "$IIWPL,5503.4530,N,01037.2742,E,411*6F",
+		msg: WPL{
+			Latitude:  MustParseLatLong("5503.4530 N"),
+			Longitude: MustParseLatLong("01037.2742 E"),
+			Ident:     "411",
+		},
+	},
+	{
+		name: "bad latitude",
+		raw:  "$IIWPL,A,N,01037.2742,E,411*01",
+		err:  "nmea: IIWPL invalid latitude: cannot parse [A N], unknown format",
+	},
+	{
+		name: "bad longitude",
+		raw:  "$IIWPL,5503.4530,N,A,E,411*36",
+		err:  "nmea: IIWPL invalid longitude: cannot parse [A E], unknown format",
+	},
+	{
+		name: "good sentence",
+		raw:  "$IIWPL,3356.4650,S,15124.5567,E,411*73",
+		msg: WPL{
+			Latitude:  MustParseLatLong("3356.4650 S"),
+			Longitude: MustParseLatLong("15124.5567 E"),
+			Ident:     "411",
+		},
+	},
+	{
+		name: "bad latitude",
+		raw:  "$IIWPL,A,S,15124.5567,E,411*18",
+		err:  "nmea: IIWPL invalid latitude: cannot parse [A S], unknown format",
+	},
+	{
+		name: "bad longitude",
+		raw:  "$IIWPL,3356.4650,S,A,E,411*2E",
+		err:  "nmea: IIWPL invalid longitude: cannot parse [A E], unknown format",
+	},
+}
+
+func TestWPL(t *testing.T) {
+	for _, tt := range wpltests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Parse(tt.raw)
+			if tt.err != "" {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				wpl := m.(WPL)
+				wpl.BaseSentence = BaseSentence{}
+				assert.Equal(t, tt.msg, wpl)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hey, thanks for the go-nmea package!

This PR adds support for `WPL` and `RTE` sentences.

I've added a new function called `ListString` in `parser.go` which is used to parse the waypoint idents in the `RTE` sentence. Not sure if this is the best way of doing it?

```sh
# Example data
$IIWPL,5503.4243,N,01037.0743,E,589*6F
$IIWPL,5503.4192,N,01037.1200,E,590*6B
$IIWPL,5503.4139,N,01037.1182,E,591*62
$IIWPL,5503.4190,N,01037.0725,E,592*68
$IIWPL,5503.4137,N,01037.0707,E,593*64
$IIWPL,5503.4086,N,01037.1164,E,594*6A
$IIWPL,5503.4033,N,01037.1146,E,595*65
$IIRTE,2,1,c,Rte 2019-0,589,590,591,592,593*4F
$IIRTE,2,2,c,Rte 2019-0,594,595*55
```