### PR TITLE
Added support for TagBlocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/adrianmo/go-nmea
+module github.com/klyve/go-nmea
 
 require github.com/stretchr/testify v1.2.1

--- a/sentence.go
+++ b/sentence.go
@@ -58,7 +58,6 @@ func (s BaseSentence) String() string { return s.Raw }
 // parseSentence parses a raw message into it's fields
 func parseSentence(raw string) (BaseSentence, error) {
 	raw = strings.TrimSpace(raw)
-	var tagBlock TagBlock
 	tagBlock, raw, err := parseTagBlock(raw)
 	if err != nil {
 		return BaseSentence{}, err

--- a/tagblock.go
+++ b/tagblock.go
@@ -41,7 +41,7 @@ type TagBlock struct {
 	Text         string // -t Variable length text
 }
 
-func parseUint(raw string) (int64, error) {
+func parseInt64(raw string) (int64, error) {
 	i, err := strconv.ParseInt(raw[2:], 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("nmea: tagblock unable to parse uint32 [%s]", raw)
@@ -86,7 +86,7 @@ func parseTagBlock(raw string) (TagBlock, string, error) {
 		}
 		switch item[:1] {
 		case TypeUnixTime:
-			tagBlock.Time, err = parseUint(item)
+			tagBlock.Time, err = parseInt64(item)
 			if err != nil {
 				return tagBlock, raw, err
 			}
@@ -95,12 +95,12 @@ func parseTagBlock(raw string) (TagBlock, string, error) {
 		case TypeGrouping:
 			tagBlock.Grouping = item[2:]
 		case TypeLineCount:
-			tagBlock.LineCount, err = parseUint(item)
+			tagBlock.LineCount, err = parseInt64(item)
 			if err != nil {
 				return tagBlock, raw, err
 			}
 		case TypeRelativeTime:
-			tagBlock.RelativeTime, err = parseUint(item)
+			tagBlock.RelativeTime, err = parseInt64(item)
 			if err != nil {
 				return tagBlock, raw, err
 			}

--- a/tagblock.go
+++ b/tagblock.go
@@ -53,59 +53,59 @@ func parseUint(raw string) (uint32, error) {
 // https://rietman.wordpress.com/2016/09/17/nemastudio-now-supports-the-nmea-0183-tag-block/
 func parseTagBlock(raw string) (TagBlock, string, error) {
 	matches := TagBlockRegexp.FindStringSubmatch(raw)
-	var tagBlock TagBlock
-	if matches != nil {
-		raw = matches[3]
-		tags := matches[2]
-		tagBlock.Head = matches[1]
-
-		sumSepIndex := strings.Index(tags, ChecksumSep)
-		if sumSepIndex == -1 {
-			return tagBlock, raw, fmt.Errorf("nmea: tagblock does not contain checksum separator")
-		}
-
-		var (
-			fieldsRaw   = tags[0:sumSepIndex]
-			checksumRaw = strings.ToUpper(tags[sumSepIndex+1:])
-			checksum    = xorChecksum(fieldsRaw)
-			err         error
-		)
-
-		// Validate the checksum
-		if checksum != checksumRaw {
-			return tagBlock, raw, fmt.Errorf("nmea: tagblock checksum mismatch [%s != %s]", checksum, checksumRaw)
-		}
-
-		data := strings.Split(tags[:sumSepIndex], ",")
-		for _, item := range data {
-			switch item[0:1] {
-			case TypeUnixTime:
-				tagBlock.Time, err = parseUint(item)
-				if err != nil {
-					return tagBlock, raw, err
-				}
-			case TypeDestinationID:
-				tagBlock.Destination = item[2:]
-			case TypeGrouping:
-				tagBlock.Grouping = item[2:]
-			case TypeLineCount:
-				tagBlock.LineCount, err = parseUint(item)
-				if err != nil {
-					return tagBlock, raw, err
-				}
-			case TypeRelativeTime:
-				tagBlock.RelativeTime, err = parseUint(item)
-				if err != nil {
-					return tagBlock, raw, err
-				}
-			case TypeSourceID:
-				tagBlock.Source = item[2:]
-			case TypeTextString:
-				tagBlock.Text = item[2:]
-			}
-		}
-
+	if matches == nil {
+		return TagBlock{}, raw, nil
 	}
 
+	tagBlock := TagBlock{}
+	raw = matches[3]
+	tags := matches[2]
+	tagBlock.Head = matches[1]
+
+	sumSepIndex := strings.Index(tags, ChecksumSep)
+	if sumSepIndex == -1 {
+		return tagBlock, raw, fmt.Errorf("nmea: tagblock does not contain checksum separator")
+	}
+
+	var (
+		fieldsRaw   = tags[0:sumSepIndex]
+		checksumRaw = strings.ToUpper(tags[sumSepIndex+1:])
+		checksum    = xorChecksum(fieldsRaw)
+		err         error
+	)
+
+	// Validate the checksum
+	if checksum != checksumRaw {
+		return tagBlock, raw, fmt.Errorf("nmea: tagblock checksum mismatch [%s != %s]", checksum, checksumRaw)
+	}
+
+	data := strings.Split(tags[:sumSepIndex], ",")
+	for _, item := range data {
+		switch item[0:1] {
+		case TypeUnixTime:
+			tagBlock.Time, err = parseUint(item)
+			if err != nil {
+				return tagBlock, raw, err
+			}
+		case TypeDestinationID:
+			tagBlock.Destination = item[2:]
+		case TypeGrouping:
+			tagBlock.Grouping = item[2:]
+		case TypeLineCount:
+			tagBlock.LineCount, err = parseUint(item)
+			if err != nil {
+				return tagBlock, raw, err
+			}
+		case TypeRelativeTime:
+			tagBlock.RelativeTime, err = parseUint(item)
+			if err != nil {
+				return tagBlock, raw, err
+			}
+		case TypeSourceID:
+			tagBlock.Source = item[2:]
+		case TypeTextString:
+			tagBlock.Text = item[2:]
+		}
+	}
 	return tagBlock, raw, nil
 }

--- a/tagblock.go
+++ b/tagblock.go
@@ -1,0 +1,111 @@
+package nmea
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// TypeUnixTime unix timestamp, parameter: -c
+	TypeUnixTime = "c"
+	// TypeDestinationID destination identification 15char max, parameter: -d
+	TypeDestinationID = "d"
+	// TypeGrouping sentence grouping, parameter: -g
+	TypeGrouping = "g"
+	// TypeLineCount linecount, parameter: -n
+	TypeLineCount = "n"
+	// TypeRelativeTime relative time time, paremeter: -r
+	TypeRelativeTime = "r"
+	// TypeSourceID source identification 15char max, paremter: -s
+	TypeSourceID = "s"
+	// TypeTextString valid character string, parameter -t
+	TypeTextString = "t"
+)
+
+var (
+	// TagBlockRegexp matches nmea tag blocks
+	TagBlockRegexp = regexp.MustCompile(`^(.*)\\(\S+)\\(.*)`)
+)
+
+// TagBlock struct
+type TagBlock struct {
+	Head         string // *
+	Time         uint32 // -c
+	RelativeTime uint32 // -r
+	Destination  string // -d 15 char max
+	Grouping     string // -g nummeric string
+	LineCount    uint32 // -n int
+	Source       string // -s 15 char max
+	Text         string // -t Variable length text
+}
+
+func parseUint(raw string) (uint32, error) {
+	i, err := strconv.ParseUint(raw[2:], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("nmea: tagblock unable to parse uint32 [%s]", raw)
+	}
+	return uint32(i), nil
+}
+
+// parseTagBlock adds support for tagblocks
+// https://rietman.wordpress.com/2016/09/17/nemastudio-now-supports-the-nmea-0183-tag-block/
+func parseTagBlock(raw string) (TagBlock, string, error) {
+	matches := TagBlockRegexp.FindStringSubmatch(raw)
+	var tagBlock TagBlock
+	if matches != nil {
+		raw = matches[3]
+		tags := matches[2]
+		tagBlock.Head = matches[1]
+
+		sumSepIndex := strings.Index(tags, ChecksumSep)
+		if sumSepIndex == -1 {
+			return tagBlock, raw, fmt.Errorf("nmea: tagblock does not contain checksum separator")
+		}
+
+		var (
+			fieldsRaw   = tags[0:sumSepIndex]
+			checksumRaw = strings.ToUpper(tags[sumSepIndex+1:])
+			checksum    = xorChecksum(fieldsRaw)
+			err         error
+		)
+
+		// Validate the checksum
+		if checksum != checksumRaw {
+			return tagBlock, raw, fmt.Errorf("nmea: tagblock checksum mismatch [%s != %s]", checksum, checksumRaw)
+		}
+
+		data := strings.Split(tags[:sumSepIndex], ",")
+		for _, item := range data {
+			switch item[0:1] {
+			case TypeUnixTime:
+				tagBlock.Time, err = parseUint(item)
+				if err != nil {
+					return tagBlock, raw, err
+				}
+			case TypeDestinationID:
+				tagBlock.Destination = item[2:]
+			case TypeGrouping:
+				tagBlock.Grouping = item[2:]
+			case TypeLineCount:
+				tagBlock.LineCount, err = parseUint(item)
+				if err != nil {
+					return tagBlock, raw, err
+				}
+			case TypeRelativeTime:
+				tagBlock.RelativeTime, err = parseUint(item)
+				if err != nil {
+					return tagBlock, raw, err
+				}
+			case TypeSourceID:
+				tagBlock.Source = item[2:]
+			case TypeTextString:
+				tagBlock.Text = item[2:]
+			}
+		}
+
+	}
+
+	return tagBlock, raw, nil
+}

--- a/tagblock_test.go
+++ b/tagblock_test.go
@@ -72,9 +72,21 @@ var tagblocktests = []struct {
 	},
 	{
 
-		name: "Test invalid int",
+		name: "Test invalid timestamp",
 		raw:  "UdPbC?\\s:satelite,c:gjadslkg*30\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
 		err:  "nmea: tagblock unable to parse uint32 [c:gjadslkg]",
+	},
+	{
+
+		name: "Test invalid linecount",
+		raw:  "UdPbC?\\s:satelite,n:gjadslkg*3D\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		err:  "nmea: tagblock unable to parse uint32 [n:gjadslkg]",
+	},
+	{
+
+		name: "Test invalid relative time",
+		raw:  "UdPbC?\\s:satelite,r:gjadslkg*21\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		err:  "nmea: tagblock unable to parse uint32 [r:gjadslkg]",
 	},
 }
 

--- a/tagblock_test.go
+++ b/tagblock_test.go
@@ -42,6 +42,37 @@ var tagblocktests = []struct {
 		},
 	},
 	{
+		name: "Test unix timestamp",
+		raw:  "UdPbC?\\x:NorSat_1,c:1564827317*42\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		msg: TagBlock{
+			Time:   1564827317,
+			Source: "",
+			Head:   "UdPbC?",
+		},
+	},
+	{
+
+		name: "Test milliseconds timestamp",
+		raw:  "UdPbC?\\x:NorSat_1,c:1564827317000*72\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		msg: TagBlock{
+			Time:   1564827317,
+			Source: "",
+			Head:   "UdPbC?",
+		},
+	},
+	{
+
+		name: "Test invalid high timestamp",
+		raw:  "UdPbC?\\x:NorSat_1,c:25648273170000000*71\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		err:  "nmea: Tagblock timestamp is not valid",
+	},
+	{
+
+		name: "Test invalid low timestamp",
+		raw:  "UdPbC?\\x:NorSat_1,c:-10*60\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		err:  "nmea: Tagblock timestamp is not valid must be between 0 and now + 24h",
+	},
+	{
 
 		name: "Test all input types",
 		raw:  "UdPbC?\\s:satelite,c:1564827317,r:1553390539,d:ara,g:bulk,n:13,t:helloworld*3F\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",

--- a/tagblock_test.go
+++ b/tagblock_test.go
@@ -1,0 +1,95 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var tagblocktests = []struct {
+	//name: "Tagblock ok",
+	//raw: "",
+	name string
+	raw  string
+	err  string
+	msg  TagBlock
+}{
+	{
+
+		name: "Test NMEA tag block",
+		raw:  "\\s:Satelite_1,c:1553390539*62\\!AIVDM,1,1,,A,13M@ah0025QdPDTCOl`K6`nV00Sv,0*52",
+		msg: TagBlock{
+			Time:   1553390539,
+			Source: "Satelite_1",
+		},
+	},
+	{
+
+		name: "Test NMEA tag block with head",
+		raw:  "UdPbC?\\s:satelite,c:1564827317*25\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		msg: TagBlock{
+			Time:   1564827317,
+			Source: "satelite",
+			Head:   "UdPbC?",
+		},
+	},
+	{
+
+		name: "Test unknown tag",
+		raw:  "UdPbC?\\x:NorSat_1,c:1564827317*42\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		msg: TagBlock{
+			Time:   1564827317,
+			Source: "",
+			Head:   "UdPbC?",
+		},
+	},
+	{
+
+		name: "Test all input types",
+		raw:  "UdPbC?\\s:satelite,c:1564827317,r:1553390539,d:ara,g:bulk,n:13,t:helloworld*3F\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		msg: TagBlock{
+			Time:         1564827317,
+			RelativeTime: 1553390539,
+			Destination:  "ara",
+			Grouping:     "bulk",
+			Source:       "satelite",
+			Head:         "UdPbC?",
+			Text:         "helloworld",
+			LineCount:    13,
+		},
+	},
+	{
+
+		name: "Test Invalid checksum",
+		raw:  "UdPbC?\\s:satelite,c:1564827317*49\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		err:  "nmea: tagblock checksum mismatch [25 != 49]",
+	},
+	{
+
+		name: "Test no checksum",
+		raw:  "UdPbC?\\s:satelite,c:156482731749\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		err:  "nmea: tagblock does not contain checksum separator",
+	},
+	{
+
+		name: "Test invalid int",
+		raw:  "UdPbC?\\s:satelite,c:gjadslkg*30\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		err:  "nmea: tagblock unable to parse uint32 [c:gjadslkg]",
+	},
+}
+
+func TestTagBlock(t *testing.T) {
+	for _, tt := range tagblocktests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Parse(tt.raw)
+			if tt.err != "" {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				vdm := m.(VDMVDO)
+				assert.Equal(t, tt.msg, vdm.BaseSentence.TagBlock)
+			}
+		})
+	}
+}

--- a/tagblock_test.go
+++ b/tagblock_test.go
@@ -7,8 +7,6 @@ import (
 )
 
 var tagblocktests = []struct {
-	//name: "Tagblock ok",
-	//raw: "",
 	name string
 	raw  string
 	err  string
@@ -57,6 +55,22 @@ var tagblocktests = []struct {
 			Text:         "helloworld",
 			LineCount:    13,
 		},
+	},
+	{
+
+		name: "Test empty tag in tagblock",
+		raw:  "UdPbC?\\s:satelite,,r:1553390539,d:ara,g:bulk,n:13,t:helloworld*68\\!AIVDM,1,1,,A,19NSRaP02A0fo91kwnaMKbjR08:J,0*15",
+		msg: TagBlock{
+			Time:         0,
+			RelativeTime: 1553390539,
+			Destination:  "ara",
+			Grouping:     "bulk",
+			Source:       "satelite",
+			Head:         "UdPbC?",
+			Text:         "helloworld",
+			LineCount:    13,
+		},
+		//err: "nmea: tagblock checksum mismatch [25 != 49]",
 	},
 	{
 


### PR DESCRIPTION
Satellites and some sources apply a tag block to the messages.
TagBlock is now parsed before any other messages and is a part of BaseSentence

Tagblocks:
https://www.nmea.org/Assets/may%2009%20rtcm%200183_v400.pdf
https://rietman.wordpress.com/2016/09/17/nemastudio-now-supports-the-nmea-0183-tag-block/
