### PR TITLE
added latitude range checking

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -19,6 +19,8 @@ func TestParseLatLong(t *testing.T) {
 		{"3345.1232 N", 33.752054, false},            // gps
 		{"151.234532", 151.234532, false},            // decimal
 		{"200.000", 0, true},                         // out of range
+		{"9100.000 N", 0, true},                      // latitude out of range
+		{"18100.000 W", 0, true},                     // longitude out of range
 	}
 	for _, tt := range tests {
 		t.Run(tt.value, func(t *testing.T) {


### PR DESCRIPTION
There was no check for latitude range. I have expanded the ParseLatLong function, which by parsing the coordinates in the GPS format will check the ranges for both latitude and longitude. The changes do not affect the public API.