### PR TITLE
Add functions for converting coordinates to their direction

### DIFF
--- a/types.go
+++ b/types.go
@@ -243,3 +243,19 @@ func ParseDate(ddmmyy string) (Date, error) {
 	}
 	return Date{true, dd, mm, yy}, nil
 }
+
+// LatDir returns the latitude direction symbol
+func LatDir(l float64) string {
+	if l < 0.0 {
+		return South
+	}
+	return North
+}
+
+// LonDir returns the longitude direction symbol
+func LonDir(l float64) string {
+	if l < 0.0 {
+		return East
+	}
+	return West
+}

--- a/types_test.go
+++ b/types_test.go
@@ -219,3 +219,33 @@ func TestDateString(t *testing.T) {
 		t.Fatalf("got %s expected %s", s, expected)
 	}
 }
+
+func TestLatDir(t *testing.T) {
+	tests := []struct {
+		value    float64
+		expected string
+	}{
+		{50.0, "N"},
+		{-50.0, "S"},
+	}
+	for _, tt := range tests {
+		if s := LatDir(tt.value); s != tt.expected {
+			t.Fatalf("got %s expected %s", s, tt.expected)
+		}
+	}
+}
+
+func TestLonDir(t *testing.T) {
+	tests := []struct {
+		value    float64
+		expected string
+	}{
+		{100.0, "W"},
+		{-100.0, "E"},
+	}
+	for _, tt := range tests {
+		if s := LonDir(tt.value); s != tt.expected {
+			t.Fatalf("got %s expected %s", s, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
Currently, the package allows you to get information about the latitude / longitude direction only for coordinates saved in the DD format. Formatting longitude / latitude to GPS / DMS format cuts out direction information, or rather tells you to read the longitude symbol as East and the latitude symbol as North, which may not necessarily be true. It may happen that some services may want to receive GPS coordinates immediately in GPS / DMS format, and these formats require the delivery of a direction sign.
My suggestion is simple and could be included in the program code. However, I think that the packet responsible for parsing NMEA frames should provide complete information about each of the supported frames, even those that are theoretically easy to obtain.