### PR TITLE
Add VHW water speed and heading sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ At this moment, this library supports the following sentence types:
 - [VDM/VDO](http://catb.org/gpsd/AIVDM.html) - Encapsulated binary payload
 - [WPL](http://aprs.gids.nl/nmea/#wpl) - Waypoint location
 - [RTE](http://aprs.gids.nl/nmea/#rte) - Route
+- [VHW](https://www.tronico.fi/OH6NT/docs/NMEA0183.pdf) - Water Speed and Heading
 
 ## Example
 

--- a/sentence.go
+++ b/sentence.go
@@ -150,6 +150,8 @@ func Parse(raw string) (Sentence, error) {
 			return newWPL(s)
 		case TypeRTE:
 			return newRTE(s)
+		case TypeVHW:
+			return newVHW(s)
 		}
 	}
 	if strings.HasPrefix(s.Raw, SentenceStartEncapsulated) {

--- a/vhw.go
+++ b/vhw.go
@@ -1,0 +1,28 @@
+package nmea
+
+const (
+	// TypeVHW type for VHW sentences
+	TypeVHW = "VHW"
+)
+
+// VHW contains information about water speed and heading
+type VHW struct {
+	BaseSentence
+	TrueHeading            float64
+	MagneticHeading        float64
+	SpeedThroughWaterKnots float64
+	SpeedThroughWaterKPH   float64
+}
+
+// newVHW constructor
+func newVHW(s BaseSentence) (VHW, error) {
+	p := newParser(s)
+	p.AssertType(TypeVHW)
+	return VHW{
+		BaseSentence:           s,
+		TrueHeading:            p.Float64(0, "true heading"),
+		MagneticHeading:        p.Float64(2, "magnetic heading"),
+		SpeedThroughWaterKnots: p.Float64(4, "speed through water in knots"),
+		SpeedThroughWaterKPH:   p.Float64(6, "speed through water in kilometers per hour"),
+	}, p.Err()
+}

--- a/vhw_test.go
+++ b/vhw_test.go
@@ -38,9 +38,9 @@ func TestVHW(t *testing.T) {
 				assert.EqualError(t, err, tt.err)
 			} else {
 				assert.NoError(t, err)
-				wpl := m.(VHW)
-				wpl.BaseSentence = BaseSentence{}
-				assert.Equal(t, tt.msg, wpl)
+				vhw := m.(VHW)
+				vhw.BaseSentence = BaseSentence{}
+				assert.Equal(t, tt.msg, vhw)
 			}
 		})
 	}

--- a/vhw_test.go
+++ b/vhw_test.go
@@ -1,0 +1,47 @@
+package nmea
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var vhw = []struct {
+	name string
+	raw  string
+	err  string
+	msg  VHW
+}{
+	{
+		name: "good sentence",
+		raw:  "$VWVHW,45.0,T,43.0,M,3.5,N,6.4,K*56",
+		msg: VHW{
+			TrueHeading:            45.0,
+			MagneticHeading:        43.0,
+			SpeedThroughWaterKnots: 3.5,
+			SpeedThroughWaterKPH:   6.4,
+		},
+	},
+	{
+		name: "bad sentence",
+		raw:  "$VWVHW,T,45.0,43.0,M,3.5,N,6.4,K*56",
+		err:  "nmea: VWVHW invalid true heading: T",
+	},
+}
+
+func TestVHW(t *testing.T) {
+	for _, tt := range vhw {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Parse(tt.raw)
+			if tt.err != "" {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				wpl := m.(VHW)
+				wpl.BaseSentence = BaseSentence{}
+				assert.Equal(t, tt.msg, wpl)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for the `VHW` sentence.

```
$VWVHW,45.0,T,43.0,M,3.5,N,6.4,K*56
```