### PR TITLE
Bugfix: when no satellite in view, GSV failed

### DIFF
--- a/gsv.go
+++ b/gsv.go
@@ -34,7 +34,7 @@ func newGSV(s BaseSentence) (GSV, error) {
 		NumberSVsInView: p.Int64(2, "number of SVs in view"),
 	}
 	for i := 0; i < 4; i++ {
-		if 5*i+4 > len(m.Fields) {
+		if 6+i*4 >= len(m.Fields) {
 			break
 		}
 		m.Info = append(m.Info, GSVInfo{

--- a/gsv_test.go
+++ b/gsv_test.go
@@ -42,6 +42,16 @@ var gsvtests = []struct {
 		},
 	},
 	{
+		name: "sentence with no satellite in view",
+		raw:  "$GBGSV,1,1,00,0*77",
+		msg: GSV{
+			TotalMessages:   1,
+			MessageNumber:   1,
+			NumberSVsInView: 0,
+			Info:            nil,
+		},
+	},
+	{
 		name: "invalid number of svs",
 		raw:  "$GLGSV,3,1,11.2,03,03,111,00,04,15,270,00,06,01,010,12,13,06,292,00*77",
 		err:  "nmea: GLGSV invalid number of SVs in view: 11.2",


### PR DESCRIPTION
Hi!

I found and fixed a bug in your (otherwise excellent!) library. When the GPS/GNSS has no satellite in view, GSV sentence parsing failed. This was a simple index check issue.
Exemple failing sentence:
`$GAGSV,1,1,00,0*74`

Thanks!
