### PR TITLE
WIP: sentence parsing stores all encountered errors and distinguishes some errors by sentence field 

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,82 @@
+package nmea
+
+import (
+	"errors"
+	"fmt"
+)
+
+// NotSupportedError is returned when parsed sentence is not supported
+type NotSupportedError struct {
+	Prefix string
+}
+
+// Error returns error message
+func (p *NotSupportedError) Error() string {
+	return fmt.Sprintf("nmea: sentence prefix '%s' not supported", p.Prefix)
+}
+
+// ParseError is error container to hold multiple error encountered during sentence parsing
+type ParseError struct {
+	Errors []error
+}
+
+func (e *ParseError) Error() string {
+	return e.Errors[0].Error()
+}
+
+// As implements errors.As by attempting to map to the current value.
+func (e *ParseError) As(target interface{}) bool {
+	for _, err := range e.Errors {
+		if ok := errors.As(err, target); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Is implements errors.Is by comparing the current value directly
+func (e *ParseError) Is(target error) bool {
+	for _, err := range e.Errors {
+		if ok := errors.Is(err, target); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// FieldError error structure related to parsing invalid field values
+type FieldError struct {
+	Prefix  string
+	Context string
+	Value   string
+}
+
+// Error returns error text
+func (e *FieldError) Error() string {
+	return fmt.Sprintf("nmea: %s invalid %s: %s", e.Prefix, e.Context, e.Value)
+}
+
+// Is implements errors.Is by comparing the current value directly
+func (e *FieldError) Is(target error) bool {
+	if t, ok := target.(*FieldError); ok {
+		return t.Prefix == e.Prefix && t.Context == e.Context && t.Value == e.Value
+	}
+	// we want FieldError to be equal to old errors created as `errors.New("nmea: HEROT invalid rate of turn: nope")` was
+	return e.Error() == target.Error()
+}
+
+// InvalidEnumCharsError is error returned when sentence has invalid character value for enum field
+type InvalidEnumCharsError FieldError
+
+// Error returns error text
+func (e *InvalidEnumCharsError) Error() string {
+	return fmt.Sprintf("nmea: %s invalid %s: %s", e.Prefix, e.Context, e.Value)
+}
+
+// InvalidEnumStringError is error returned when enum field in sentence has invalid value
+type InvalidEnumStringError FieldError
+
+// Error returns error text
+func (e *InvalidEnumStringError) Error() string {
+	return fmt.Sprintf("nmea: %s invalid %s: %s", e.Prefix, e.Context, e.Value)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,140 @@
+package nmea
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseError_As(t *testing.T) {
+	_, err := Parse("$HEROT,-11.23,X*1E")
+
+	assert.Equal(t, &ParseError{Errors: []error{&InvalidEnumStringError{
+		Prefix:  "HEROT",
+		Context: "status valid",
+		Value:   "X",
+	}}}, err)
+
+	var expect *InvalidEnumStringError
+	as := errors.As(err, &expect)
+	assert.True(t, as)
+	assert.Equal(t, "HEROT", expect.Prefix)
+	assert.Equal(t, "status valid", expect.Context)
+	assert.Equal(t, "X", expect.Value)
+
+	var expect2 *NotSupportedError
+	asFalse := errors.As(err, &expect2)
+	assert.False(t, asFalse)
+}
+
+func TestParseError_Is(t *testing.T) {
+	_, err := Parse("$HEROT,-11.23,X*1E")
+
+	errInvalidEnum := &InvalidEnumStringError{
+		Prefix:  "HEROT",
+		Context: "status valid",
+		Value:   "X",
+	}
+	assert.Equal(t, &ParseError{Errors: []error{errInvalidEnum}}, err)
+
+	isTrue := errors.Is(err, errInvalidEnum)
+	assert.False(t, isTrue)
+
+	var expectNot *NotSupportedError
+	isFalse := errors.Is(err, expectNot)
+	assert.False(t, isFalse)
+}
+
+func TestParseError_WithMultipleErrors(t *testing.T) {
+	m, err := Parse("$HEROT,nope,X*08")
+
+	assert.Equal(t, ROT{
+		BaseSentence: BaseSentence{
+			Talker:   "HE",
+			Type:     "ROT",
+			Fields:   []string{"nope", "X"},
+			Checksum: "08",
+			Raw:      "$HEROT,nope,X*08",
+			TagBlock: TagBlock{},
+		},
+		RateOfTurn: 0,
+		Valid:      false,
+	}, m)
+
+	assert.Equal(t, &ParseError{
+		Errors: []error{
+			&FieldError{
+				Prefix:  "HEROT",
+				Context: "rate of turn",
+				Value:   "nope",
+			},
+			&InvalidEnumStringError{
+				Prefix:  "HEROT",
+				Context: "status valid",
+				Value:   "X",
+			},
+		},
+	}, err)
+
+	var expect *InvalidEnumStringError
+	assert.True(t, errors.As(err, &expect))
+	assert.Equal(t,
+		&InvalidEnumStringError{
+			Prefix:  "HEROT",
+			Context: "status valid",
+			Value:   "X",
+		},
+		expect,
+	)
+
+	assert.True(t, errors.Is(err, errors.New("nmea: HEROT invalid rate of turn: nope")))
+	assert.True(t, errors.Is(err, &InvalidEnumStringError{
+		Prefix:  "HEROT",
+		Context: "rate of turn",
+		Value:   "nope",
+	}))
+}
+
+func TestFieldError_Is(t *testing.T) {
+	var testCases = []struct {
+		name   string
+		when   error
+		expect bool
+	}{
+		{
+			name: "is same",
+			when: &FieldError{
+				Prefix:  "HEROT",
+				Context: "rate of turn",
+				Value:   "nope",
+			},
+			expect: true,
+		},
+		{
+			name: "is not exactly same",
+			when: &FieldError{
+				Prefix:  "XXX",
+				Context: "rate of turn",
+				Value:   "nope",
+			},
+			expect: false,
+		},
+		{
+			name:   "is not same",
+			when:   &NotSupportedError{Prefix: "HEROT"},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &FieldError{
+				Prefix:  "HEROT",
+				Context: "rate of turn",
+				Value:   "nope",
+			}
+			is := errors.Is(err, tc.when)
+			assert.Equal(t, tc.expect, is)
+		})
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,316 +1,781 @@
 package nmea
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-var parsertests = []struct {
-	name     string
-	fields   []string
-	expected interface{}
-	hasErr   bool
-	parse    func(p *Parser) interface{}
-}{
-	{
-		name:   "Bad Type",
-		fields: []string{},
-		hasErr: true,
-		parse: func(p *Parser) interface{} {
-			p.AssertType("WRONG_TYPE")
-			return nil
+func TestParser_AssertType(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		givenType   string
+		whenType    string
+		expectError string
+	}{
+		{
+			name:        "ok type",
+			givenType:   "RMC",
+			whenType:    "RMC",
+			expectError: "",
 		},
-	},
-	{
-		name:     "String",
-		fields:   []string{"foo", "bar"},
-		expected: "bar",
-		parse: func(p *Parser) interface{} {
-			return p.String(1, "")
+		{
+			name:        "bad type",
+			givenType:   "RMC",
+			whenType:    "RMB",
+			expectError: "nmea: talkerRMC invalid type: RMC",
 		},
-	},
-	{
-		name:     "String out of range",
-		fields:   []string{"wot"},
-		expected: "",
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.String(5, "thing")
-		},
-	},
-	{
-		name:     "ListString",
-		fields:   []string{"wot", "foo", "bar"},
-		expected: []string{"foo", "bar"},
-		parse: func(p *Parser) interface{} {
-			return p.ListString(1, "thing")
-		},
-	},
-	{
-		name:     "ListString out of range",
-		fields:   []string{"wot"},
-		expected: []string{},
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.ListString(10, "thing")
-		},
-	},
-	{
-		name:     "String with existing error",
-		expected: "",
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			p.SetErr("context", "value")
-			return p.String(123, "blah")
-		},
-	},
-	{
-		name:     "EnumString",
-		fields:   []string{"a", "b", "c"},
-		expected: "b",
-		parse: func(p *Parser) interface{} {
-			return p.EnumString(1, "context", "b", "d")
-		},
-	},
-	{
-		name:     "EnumString invalid",
-		fields:   []string{"a", "b", "c"},
-		expected: "",
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.EnumString(1, "context", "x", "y")
-		},
-	},
-	{
-		name:     "EnumString with existing error",
-		fields:   []string{"a", "b", "c"},
-		expected: "",
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			p.SetErr("context", "value")
-			return p.EnumString(1, "context", "a", "b")
-		},
-	},
-	{
-		name:     "EnumChars",
-		fields:   []string{"AA", "AB", "BA", "BB"},
-		expected: []string{"A", "B"},
-		parse: func(p *Parser) interface{} {
-			return p.EnumChars(1, "context", "A", "B")
-		},
-	},
-	{
-		name:     "EnumChars invalid",
-		fields:   []string{"a", "AB", "c"},
-		expected: []string{},
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.EnumChars(1, "context", "X", "Y")
-		},
-	},
-	{
-		name:     "EnumChars with existing error",
-		fields:   []string{"a", "AB", "c"},
-		expected: []string{},
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			p.SetErr("context", "value")
-			return p.EnumChars(1, "context", "A", "B")
-		},
-	},
-	{
-		name:     "Int64",
-		fields:   []string{"123"},
-		expected: int64(123),
-		parse: func(p *Parser) interface{} {
-			return p.Int64(0, "context")
-		},
-	},
-	{
-		name:     "Int64 empty field is zero",
-		fields:   []string{""},
-		expected: int64(0),
-		parse: func(p *Parser) interface{} {
-			return p.Int64(0, "context")
-		},
-	},
-	{
-		name:     "Int64 invalid",
-		fields:   []string{"abc"},
-		expected: int64(0),
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.Int64(0, "context")
-		},
-	},
-	{
-		name:     "Int64 with existing error",
-		fields:   []string{"123"},
-		expected: int64(0),
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			p.SetErr("context", "value")
-			return p.Int64(0, "context")
-		},
-	},
-	{
-		name:     "Float64",
-		fields:   []string{"123.123"},
-		expected: float64(123.123),
-		parse: func(p *Parser) interface{} {
-			return p.Float64(0, "context")
-		},
-	},
-	{
-		name:     "Float64 empty field is zero",
-		fields:   []string{""},
-		expected: float64(0),
-		parse: func(p *Parser) interface{} {
-			return p.Float64(0, "context")
-		},
-	},
-	{
-		name:     "Float64 invalid",
-		fields:   []string{"abc"},
-		expected: float64(0),
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.Float64(0, "context")
-		},
-	},
-	{
-		name:     "Float64 with existing error",
-		fields:   []string{"123.123"},
-		expected: float64(0),
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			p.SetErr("context", "value")
-			return p.Float64(0, "context")
-		},
-	},
-	{
-		name:     "Time",
-		fields:   []string{"123456"},
-		expected: Time{true, 12, 34, 56, 0},
-		parse: func(p *Parser) interface{} {
-			return p.Time(0, "context")
-		},
-	},
-	{
-		name:     "Time empty field is zero",
-		fields:   []string{""},
-		expected: Time{},
-		parse: func(p *Parser) interface{} {
-			return p.Time(0, "context")
-		},
-	},
-	{
-		name:     "Time with existing error",
-		fields:   []string{"123456"},
-		expected: Time{},
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			p.SetErr("context", "value")
-			return p.Time(0, "context")
-		},
-	},
-	{
-		name:     "Time invalid",
-		fields:   []string{"wrong"},
-		expected: Time{},
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.Time(0, "context")
-		},
-	},
-	{
-		name:     "Date",
-		fields:   []string{"010203"},
-		expected: Date{true, 1, 2, 3},
-		parse: func(p *Parser) interface{} {
-			return p.Date(0, "context")
-		},
-	},
-	{
-		name:     "Date empty field is zero",
-		fields:   []string{""},
-		expected: Date{},
-		parse: func(p *Parser) interface{} {
-			return p.Date(0, "context")
-		},
-	},
-	{
-		name:     "Date invalid",
-		fields:   []string{"Hello"},
-		expected: Date{},
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.Date(0, "context")
-		},
-	},
-	{
-		name:     "Date with existing error",
-		fields:   []string{"010203"},
-		expected: Date{},
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			p.SetErr("context", "value")
-			return p.Date(0, "context")
-		},
-	},
-	{
-		name:     "LatLong",
-		fields:   []string{"5000.0000", "N"},
-		expected: 50.0,
-		parse: func(p *Parser) interface{} {
-			return p.LatLong(0, 1, "context")
-		},
-	},
-	{
-		name:     "LatLong - latitude out of range",
-		fields:   []string{"9100.0000", "N"},
-		expected: 0.0,
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.LatLong(0, 1, "context")
-		},
-	},
-	{
-		name:     "LatLong - longitude out of range",
-		fields:   []string{"18100.0000", "W"},
-		expected: 0.0,
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			return p.LatLong(0, 1, "context")
-		},
-	},
-	{
-		name:     "LatLong with existing error",
-		fields:   []string{"5000.0000", "W"},
-		expected: 0.0,
-		hasErr:   true,
-		parse: func(p *Parser) interface{} {
-			p.SetErr("context", "value")
-			return p.LatLong(0, 1, "context")
-		},
-	},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   tc.givenType,
+			})
+
+			p.AssertType(tc.whenType)
+
+			err := p.Err()
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
-func TestParser(t *testing.T) {
-	for _, tt := range parsertests {
-		t.Run(tt.name, func(t *testing.T) {
+func TestParser_String(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		givenFields []string
+		givenError  error
+		expect      string
+		expectError error
+	}{
+		{
+			name:        "ok, string",
+			givenFields: []string{"foo", "bar"},
+			expect:      "bar",
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"wot"},
+			expect:      "",
+			expectError: &ParseError{Errors: []error{errors.New("nmea: talkertype invalid context: index out of range")}},
+		},
+		{
+			name:        "ok, string + already existing error",
+			givenFields: []string{"foo", "bar"},
+			givenError:  errors.New("existing"),
+			expect:      "bar",
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, string + already existing error",
+			givenFields: []string{"bar"},
+			givenError:  errors.New("existing"),
+			expect:      "",
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				errors.New("nmea: talkertype invalid context: index out of range"),
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			p := NewParser(BaseSentence{
 				Talker: "talker",
 				Type:   "type",
-				Fields: tt.fields,
+				Fields: tc.givenFields,
 			})
-			assert.Equal(t, tt.expected, tt.parse(p))
-			if tt.hasErr {
-				assert.Error(t, p.Err())
-			} else {
-				assert.NoError(t, p.Err())
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
 			}
+
+			result := p.String(1, "context")
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
+		})
+	}
+}
+
+func TestParser_ListString(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		givenFields []string
+		givenError  error
+		expect      []string
+		expectError error
+	}{
+		{
+			name:        "ok, ListString",
+			givenFields: []string{"wot", "foo", "bar"},
+			expect:      []string{"foo", "bar"},
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"wot"},
+			expect:      []string{},
+			expectError: &ParseError{Errors: []error{errors.New("nmea: talkertype invalid context: index out of range")}},
+		},
+		{
+			name:        "ok, ListString + already existing error",
+			givenFields: []string{"foo", "bar"},
+			givenError:  errors.New("existing"),
+			expect:      []string{"bar"},
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, ListString + already existing error",
+			givenFields: []string{"bar"},
+			givenError:  errors.New("existing"),
+			expect:      []string{},
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				errors.New("nmea: talkertype invalid context: index out of range"),
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.ListString(1, "context")
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
+		})
+	}
+}
+
+func TestParser_EnumString(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		givenFields []string
+		givenError  error
+		whenOptions []string
+		expect      string
+		expectError error
+	}{
+		{
+			name:        "ok, EnumString",
+			givenFields: []string{"180", HeadingMagnetic},
+			whenOptions: []string{HeadingTrue, HeadingMagnetic},
+			expect:      HeadingMagnetic,
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"180"},
+			whenOptions: []string{HeadingTrue, HeadingMagnetic},
+			expect:      "",
+			expectError: &ParseError{Errors: []error{errors.New("nmea: talkertype invalid context: index out of range")}},
+		},
+		{
+			name:        "ok, EnumString + already existing error",
+			givenFields: []string{"180", HeadingMagnetic},
+			givenError:  errors.New("existing"),
+			whenOptions: []string{HeadingTrue, HeadingMagnetic},
+			expect:      HeadingMagnetic,
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, EnumString + already existing error",
+			givenFields: []string{"180"},
+			givenError:  errors.New("existing"),
+			whenOptions: []string{HeadingTrue, HeadingMagnetic},
+			expect:      "",
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				errors.New("nmea: talkertype invalid context: index out of range"),
+			}},
+		},
+		{
+			name:        "nok, invalid option + already existing error",
+			givenFields: []string{"180", HeadingMagnetic},
+			givenError:  errors.New("existing"),
+			whenOptions: []string{Left, Right},
+			expect:      HeadingMagnetic,
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				&InvalidEnumStringError{Prefix: "talkertype", Context: "context", Value: "M"},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.EnumString(1, "context", tc.whenOptions...)
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
+		})
+	}
+}
+
+func TestParser_EnumChars(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		givenFields []string
+		givenError  error
+		whenOptions []string
+		expect      []string
+		expectError error
+	}{
+		{
+			name:        "ok, EnumChars",
+			givenFields: []string{"AA", "AB", "BA", "BB"},
+			whenOptions: []string{"A", "B"},
+			expect:      []string{"A", "B"},
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"AA"},
+			whenOptions: []string{"A", "B"},
+			expect:      []string{},
+			expectError: &ParseError{Errors: []error{errors.New("nmea: talkertype invalid context: index out of range")}},
+		},
+		{
+			name:        "ok, EnumChars + already existing error",
+			givenFields: []string{"AA", "AB", "BA", "BB"},
+			givenError:  errors.New("existing"),
+			whenOptions: []string{"A", "B"},
+			expect:      []string{"A", "B"},
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, EnumChars + already existing error",
+			givenFields: []string{"AA"},
+			givenError:  errors.New("existing"),
+			whenOptions: []string{"A", "B"},
+			expect:      []string{},
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				errors.New("nmea: talkertype invalid context: index out of range"),
+			}},
+		},
+		{
+			name:        "nok, invalid option + already existing error",
+			givenFields: []string{"AA", "AB"},
+			givenError:  errors.New("existing"),
+			whenOptions: []string{"A", "X"},
+			expect:      []string{"A"},
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				&InvalidEnumCharsError{Prefix: "talkertype", Context: "context", Value: "AB"},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.EnumChars(1, "context", tc.whenOptions...)
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
+		})
+	}
+}
+
+func TestParser_Int64(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		givenFields   []string
+		givenError    error
+		expect        int64
+		expectError   error
+		expectErrorIs error
+	}{
+		{
+			name:        "ok, Int64",
+			givenFields: []string{"1", "2", "3"},
+			expect:      2,
+		},
+		{
+			name:        "ok, field is empty",
+			givenFields: []string{"11", "", "22"},
+			expect:      0,
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"1"},
+			expect:      0,
+			expectError: &ParseError{Errors: []error{errors.New("nmea: talkertype invalid context: index out of range")}},
+		},
+		{
+			name:        "nok, can not be parsed to Int64",
+			givenFields: []string{"1", "ABC"},
+			expect:      0,
+			expectError: &ParseError{
+				Errors: []error{
+					&FieldError{Prefix: "talkertype", Context: "context", Value: "ABC"},
+				},
+			},
+			expectErrorIs: errors.New("nmea: talkertype invalid context: ABC"),
+		},
+		{
+			name:        "ok, Int64 + already existing error",
+			givenFields: []string{"1", "2"},
+			givenError:  errors.New("existing"),
+			expect:      2,
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, Int64 + already existing error",
+			givenFields: []string{"1"},
+			givenError:  errors.New("existing"),
+			expect:      0,
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				errors.New("nmea: talkertype invalid context: index out of range"),
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.Int64(1, "context")
+
+			err := p.Err()
+			assert.Equal(t, tc.expectError, err)
+			if tc.expectErrorIs != nil {
+				assert.True(t, errors.Is(err, tc.expectErrorIs))
+			}
+			assert.Equal(t, tc.expect, result)
+		})
+	}
+}
+
+func TestParser_Float64(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		givenFields   []string
+		givenError    error
+		expect        float64
+		expectError   error
+		expectErrorIs error
+	}{
+		{
+			name:        "ok, Float64",
+			givenFields: []string{"1.2", "2.3", "3.4"},
+			expect:      2.3,
+		},
+		{
+			name:        "ok, field is empty",
+			givenFields: []string{"1.2", "", "3.4"},
+			expect:      0,
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"1.2"},
+			expect:      0,
+			expectError: &ParseError{Errors: []error{errors.New("nmea: talkertype invalid context: index out of range")}},
+		},
+		{
+			name:        "nok, can not be parsed to Float64",
+			givenFields: []string{"1.2", "ABC"},
+			expect:      0,
+			expectError: &ParseError{
+				Errors: []error{
+					&FieldError{Prefix: "talkertype", Context: "context", Value: "ABC"},
+				},
+			},
+			expectErrorIs: errors.New("nmea: talkertype invalid context: ABC"),
+		},
+		{
+			name:        "ok, Float64 + already existing error",
+			givenFields: []string{"1.2", "2.3"},
+			givenError:  errors.New("existing"),
+			expect:      2.3,
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, Float64 + already existing error",
+			givenFields: []string{"1.2"},
+			givenError:  errors.New("existing"),
+			expect:      0,
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				errors.New("nmea: talkertype invalid context: index out of range"),
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.Float64(1, "context")
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
+		})
+	}
+}
+
+func TestParser_Time(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		givenFields   []string
+		givenError    error
+		expect        Time
+		expectError   error
+		expectErrorIs error
+	}{
+		{
+			name:        "ok, Time",
+			givenFields: []string{"x", "123456", "x"},
+			expect:      Time{true, 12, 34, 56, 0},
+		},
+		{
+			name:        "ok, field is empty",
+			givenFields: []string{"1.2", "", "3.4"},
+			expect:      Time{false, 0, 0, 0, 0},
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"1.2"},
+			expect:      Time{false, 0, 0, 0, 0},
+			expectError: &ParseError{Errors: []error{errors.New("nmea: talkertype invalid context: index out of range")}},
+		},
+		{
+			name:        "nok, can not be parsed to Time",
+			givenFields: []string{"1.2", "ABC"},
+			expect:      Time{false, 0, 0, 0, 0},
+			expectError: &ParseError{
+				Errors: []error{
+					&FieldError{Prefix: "talkertype", Context: "context", Value: "ABC"},
+				},
+			},
+			expectErrorIs: errors.New("nmea: talkertype invalid context: ABC"),
+		},
+		{
+			name:        "ok, Time + already existing error",
+			givenFields: []string{"x", "123456", "x"},
+			givenError:  errors.New("existing"),
+			expect:      Time{true, 12, 34, 56, 0},
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, Time + already existing error",
+			givenFields: []string{"1.2"},
+			givenError:  errors.New("existing"),
+			expect:      Time{false, 0, 0, 0, 0},
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				errors.New("nmea: talkertype invalid context: index out of range"),
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.Time(1, "context")
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
+		})
+	}
+}
+
+func TestParser_Date(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		givenFields   []string
+		givenError    error
+		expect        Date
+		expectError   error
+		expectErrorIs error
+	}{
+		{
+			name:        "ok, Date",
+			givenFields: []string{"x", "010203", "x"},
+			expect:      Date{true, 1, 2, 3},
+		},
+		{
+			name:        "ok, field is empty",
+			givenFields: []string{"1.2", "", "3.4"},
+			expect:      Date{},
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"1.2"},
+			expect:      Date{},
+			expectError: &ParseError{Errors: []error{errors.New("nmea: talkertype invalid context: index out of range")}},
+		},
+		{
+			name:        "nok, can not be parsed to Date",
+			givenFields: []string{"1.2", "ABC"},
+			expect:      Date{},
+			expectError: &ParseError{
+				Errors: []error{
+					&FieldError{Prefix: "talkertype", Context: "context", Value: "ABC"},
+				},
+			},
+			expectErrorIs: errors.New("nmea: talkertype invalid context: ABC"),
+		},
+		{
+			name:        "ok, Date + already existing error",
+			givenFields: []string{"x", "010203", "x"},
+			givenError:  errors.New("existing"),
+			expect:      Date{true, 1, 2, 3},
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, Date + already existing error",
+			givenFields: []string{"1.2"},
+			givenError:  errors.New("existing"),
+			expect:      Date{},
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				errors.New("nmea: talkertype invalid context: index out of range"),
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.Date(1, "context")
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
+		})
+	}
+}
+
+func TestParser_LatLong(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		givenFields   []string
+		givenError    error
+		expect        float64
+		expectError   error
+		expectErrorIs error
+	}{
+		{
+			name:        "ok, LatLong",
+			givenFields: []string{"5000.0000", "N"},
+			expect:      50.0,
+		},
+		{
+			name:        "ok, field is empty",
+			givenFields: []string{"", "", "3.4"},
+			expect:      0,
+		},
+		{
+			name:        "nok, index out of range",
+			givenFields: []string{"5000.0000"},
+			expect:      0,
+			expectError: &ParseError{Errors: []error{
+				errors.New("nmea: talkertype invalid context: index out of range"),
+				&FieldError{Prefix: "talkertype", Context: "context", Value: "cannot parse [5000.0000 ], unknown format"},
+			}},
+		},
+		{
+			name:        "nok, can not be parsed to LatLong",
+			givenFields: []string{"5000.0XX", "N"},
+			expect:      0,
+			expectError: &ParseError{Errors: []error{
+				&FieldError{Prefix: "talkertype", Context: "context", Value: "cannot parse [5000.0XX N], unknown format"},
+			}},
+		},
+		{
+			name:        "nok, latitude out of range",
+			givenFields: []string{"9100.0000", "N"},
+			expect:      0,
+			expectError: &ParseError{Errors: []error{
+				&FieldError{Prefix: "talkertype", Context: "context", Value: "latitude is not in range (-90, 90)"},
+			}},
+		},
+		{
+			name:        "nok, longitude out of range",
+			givenFields: []string{"18100.0000", "W"},
+			expect:      0,
+			expectError: &ParseError{Errors: []error{
+				&FieldError{Prefix: "talkertype", Context: "context", Value: "longitude is not in range (-180, 180)"},
+			}},
+		},
+		{
+			name:        "ok, LatLong + already existing error",
+			givenFields: []string{"5000.0000", "W"},
+			givenError:  errors.New("existing"),
+			expect:      -50.0,
+			expectError: &ParseError{Errors: []error{errors.New("existing")}},
+		},
+		{
+			name:        "nok, LatLong + already existing error",
+			givenFields: []string{"5000.0000", "X"},
+			givenError:  errors.New("existing"),
+			expect:      0,
+			expectError: &ParseError{Errors: []error{
+				errors.New("existing"),
+				&FieldError{Prefix: "talkertype", Context: "context", Value: "cannot parse [5000.0000 X], unknown format"},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.LatLong(0, 1, "context")
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
+		})
+	}
+}
+
+func TestParser_SixBitASCIIArmour(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		givenFields  []string
+		givenError   error
+		whenFillBits int
+		expect       []byte
+		expectError  error
+	}{
+		{
+			name:         "ok, SixBitASCIIArmour",
+			givenFields:  []string{"13aGt0PP0jPN@9fMPKVDJgwfR>`<"},
+			whenFillBits: 0,
+			expect: []byte{
+				0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+				1, 1, 1, 0, 1, 0, 0, 1, 0, 1,
+				0, 1, 1, 1, 1, 1, 1, 1, 0, 0,
+				0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+				0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 1, 1, 0, 0, 1, 0,
+				1, 0, 0, 0, 0, 0, 0, 1, 1, 1,
+				1, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+				1, 0, 0, 1, 1, 0, 1, 1, 1, 0,
+				0, 1, 1, 1, 0, 1, 1, 0, 0, 0,
+				0, 0, 0, 1, 1, 0, 1, 1, 1, 0,
+				0, 1, 1, 0, 0, 1, 0, 1, 0, 0,
+				0, 1, 1, 0, 1, 0, 1, 0, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+				1, 1, 1, 0, 1, 0, 0, 0, 1, 0,
+				0, 0, 1, 1, 1, 0, 1, 0, 1, 0,
+				0, 0, 0, 0, 1, 1, 0, 0,
+			},
+		},
+		{
+			name:         "ok, SixBitASCIIArmour with fillbits = 2",
+			givenFields:  []string{"H77nSfPh4U=<E`H4U8G;:222220"},
+			whenFillBits: 2,
+			expect: []byte{
+				0, 1, 1, 0, 0, 0, 0, 0, 0, 1,
+				1, 1, 0, 0, 0, 1, 1, 1, 1, 1,
+				0, 1, 1, 0, 1, 0, 0, 0, 1, 1,
+				1, 0, 1, 1, 1, 0, 1, 0, 0, 0,
+				0, 0, 1, 1, 0, 0, 0, 0, 0, 0,
+				0, 1, 0, 0, 1, 0, 0, 1, 0, 1,
+				0, 0, 1, 1, 0, 1, 0, 0, 1, 1,
+				0, 0, 0, 1, 0, 1, 0, 1, 1, 0,
+				1, 0, 0, 0, 0, 1, 1, 0, 0, 0,
+				0, 0, 0, 1, 0, 0, 1, 0, 0, 1,
+				0, 1, 0, 0, 1, 0, 0, 0, 0, 1,
+				0, 1, 1, 1, 0, 0, 1, 0, 1, 1,
+				0, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+				1, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+				0, 0, 1, 0, 0, 0, 0, 0, 1, 0,
+				0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			name:         "ok, empty is ok",
+			givenFields:  []string{""},
+			whenFillBits: 0,
+			expect:       []byte{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(BaseSentence{
+				Talker: "talker",
+				Type:   "type",
+				Fields: tc.givenFields,
+			})
+			if tc.givenError != nil {
+				p.setError(tc.givenError)
+			}
+
+			result := p.SixBitASCIIArmour(0, tc.whenFillBits, "context")
+
+			assert.Equal(t, tc.expect, result)
+			assert.Equal(t, tc.expectError, p.Err())
 		})
 	}
 }

--- a/sentence.go
+++ b/sentence.go
@@ -28,16 +28,6 @@ var (
 // ParserFunc callback used to parse specific sentence variants
 type ParserFunc func(BaseSentence) (Sentence, error)
 
-// NotSupportedError is returned when parsed sentence is not supported
-type NotSupportedError struct {
-	Prefix string
-}
-
-// Error returns error message
-func (p *NotSupportedError) Error() string {
-	return fmt.Sprintf("nmea: sentence prefix '%s' not supported", p.Prefix)
-}
-
 // Sentence interface for all NMEA sentence
 type Sentence interface {
 	fmt.Stringer
@@ -136,7 +126,7 @@ func parsePrefix(s string) (string, string) {
 	return s[:2], s[2:]
 }
 
-// Checksum xor all the bytes in a string an return it
+// Checksum xor all the bytes in a string and return it
 // as an uppercase hex string
 func Checksum(s string) string {
 	var checksum uint8

--- a/types.go
+++ b/types.go
@@ -342,18 +342,7 @@ func ParseTime(s string) (Time, error) {
 	minute, _ := strconv.Atoi(s[2:4])
 	second, _ := strconv.ParseFloat(s[4:], 64)
 	whole, frac := math.Modf(second)
-	return Time{true, hour, minute, int(whole), int(round(frac * 1000))}, nil
-}
-
-// round is implemented here because it wasn't added until go1.10
-// this code is taken directly from the math.Round documentation
-// TODO: use math.Round after a reasonable amount of time
-func round(x float64) float64 {
-	t := math.Trunc(x)
-	if math.Abs(x-t) >= 0.5 {
-		return t + math.Copysign(1, x)
-	}
-	return t
+	return Time{true, hour, minute, int(whole), int(math.Round(frac * 1000))}, nil
 }
 
 // Date type


### PR DESCRIPTION
This is related to https://github.com/adrianmo/go-nmea/issues/89
sentence parsing stores all encountered errors and distinguishes some errors by sentence field type.

I have been sitting on this PR for some time. It does not seems particularly clean and really maybe worth even merging. I am pushing it up and opening this PR just to start a discussion to see if there is something worth having. 