### PR TITLE
Fix XDR missing N (Newtons) as measurement unit enum value

### DIFF
--- a/types.go
+++ b/types.go
@@ -42,6 +42,8 @@ const (
 	UnitKilogramPerCubicMetre = "K"
 	// UnitMeters is unit of distance in Meters
 	UnitMeters = DistanceUnitMetre
+	// UnitNewtons is unit of force in Newtons (1 kg*m/s2)
+	UnitNewtons = "N"
 	// UnitCubicMeters is unit of volume in cubic meters
 	UnitCubicMeters = "M"
 	// UnitRevolutionsPerMinute is unit of rotational speed or the frequency of rotation around a fixed axis in revolutions per minute (RPM)

--- a/xdr.go
+++ b/xdr.go
@@ -151,6 +151,7 @@ func newXDR(s BaseSentence) (XDR, error) {
 				UnitLitresPerSecond,
 				UnitKelvin,
 				UnitKilogramPerCubicMetre,
+				UnitNewtons,
 				UnitMeters,
 				UnitCubicMeters,
 				UnitRevolutionsPerMinute,

--- a/xdr_test.go
+++ b/xdr_test.go
@@ -40,6 +40,19 @@ func TestXDR(t *testing.T) {
 			},
 		},
 		{
+			name: "good sentence with 4 measurements",
+			raw:  "$WIXDR,C,9.7,C,2,U,24.1,N,0,U,24.4,V,1,U,3.510,V,2*46",
+			msg: XDR{
+				Measurements: []XDRMeasurement{
+					{TransducerType: "C", Value: 9.7, Unit: "C", TransducerName: "2"},
+					// U+N - Voltage+Newtons? This is real sentence from actual vessel nmea0183 bus. Maybe misconfigured device?
+					{TransducerType: "U", Value: 24.1, Unit: "N", TransducerName: "0"},
+					{TransducerType: "U", Value: 24.4, Unit: "V", TransducerName: "1"},
+					{TransducerType: "U", Value: 3.510, Unit: "V", TransducerName: "2"},
+				},
+			},
+		},
+		{
 			name: "invalid nmea: odd number of fields",
 			raw:  "$HCXDR,A,171,D,PITCH,A,-37,D,ROLL,G,367,,MAGX,G,2420,MAGY,G,-8984,,MAGZ*6d",
 			err:  "XDR field count is not exactly dividable by 4",


### PR DESCRIPTION
XDR is missing Newtons as measurement unit. Test has situation where transducer type is "Voltage" and unit is "Newtons". Found this from vessel we are upgrading at the moment - probably misconfigured unit in that device settings.