### PR TITLE
Add support for optional values

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Value: 5133.820000
 
 ### Message parsing with optional values
 
-Some messages have optional fields. By default, omitted numeric values are set to 0. In situations where you need finer control to distinguish between an undefined value and an actual 0, you can register types overriding existing sentences, using `nmea.Int64` and `nmea.Float64` instead of `int64` and `float64`. The matching parsing methods are `parser.NullInt64` and `parser.NullFloat64`. Both `nmea.Int64` and `nmea.Float64` contains a numeric field `Value` which is defined only if the field `Valid` is `true`.
+Some messages have optional fields. By default, omitted numeric values are set to 0. In situations where you need finer control to distinguish between an undefined value and an actual 0, you can register types overriding existing sentences, using `nmea.Int64` and `nmea.Float64` instead of `int64` and `float64`. The matching parsing methods are `(*Parser).NullInt64` and `(*Parser).NullFloat64`. Both `nmea.Int64` and `nmea.Float64` contains a numeric field `Value` which is defined only if the field `Valid` is `true`.
 
 See below example for a modified VTG sentence parser:
 
@@ -308,16 +308,15 @@ func main() {
 		panic(err)
 	}
 
-	switch m := s.(type) {
-	case VTG:
-		fmt.Printf("Raw sentence: %v\n", m)
-		fmt.Printf("TrueTrack: %v\n", m.TrueTrack)
-		fmt.Printf("MagneticTrack: %v\n", m.MagneticTrack)
-		fmt.Printf("GroundSpeedKnots: %v\n", m.GroundSpeedKnots)
-		fmt.Printf("GroundSpeedKPH: %v\n", m.GroundSpeedKPH)
-	default:
+	m, ok := s.(VTG)
+	if !ok {
 		panic("Could not parse VTG sentence")
 	}
+	fmt.Printf("Raw sentence: %v\n", m)
+	fmt.Printf("TrueTrack: %v\n", m.TrueTrack)
+	fmt.Printf("MagneticTrack: %v\n", m.MagneticTrack)
+	fmt.Printf("GroundSpeedKnots: %v\n", m.GroundSpeedKnots)
+	fmt.Printf("GroundSpeedKPH: %v\n", m.GroundSpeedKPH)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,74 @@ Counter: 23
 Value: 5133.820000
 ```
 
+### Message parsing with optional values
+
+Some messages have optional fields. By default, omitted numeric values are set to 0. In situations where you need finer control to distinguish between an undefined value and an actual 0, you can register types overriding existing sentences, using `nmea.Int64` and `nmea.Float64` instead of `int64` and `float64`. The matching parsing methods are `parser.NullInt64` and `parser.NullFloat64`. Both `nmea.Int64` and `nmea.Float64` contains a numeric field `Value` which is defined only if the field `Valid` is `true`.
+
+See below example for a modified VTG sentence parser:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/adrianmo/go-nmea"
+)
+
+// VTG represents track & speed data.
+// http://aprs.gids.nl/nmea/#vtg
+type VTG struct {
+	nmea.BaseSentence
+	TrueTrack        nmea.Float64
+	MagneticTrack    nmea.Float64
+	GroundSpeedKnots nmea.Float64
+	GroundSpeedKPH   nmea.Float64
+}
+
+func main() {
+	nmea.MustRegisterParser("VTG", func(s nmea.BaseSentence) (nmea.Sentence, error) {
+		p := nmea.NewParser(s)
+		return VTG{
+			BaseSentence:     s,
+			TrueTrack:        p.NullFloat64(0, "true track"),
+			MagneticTrack:    p.NullFloat64(2, "magnetic track"),
+			GroundSpeedKnots: p.NullFloat64(4, "ground speed (knots)"),
+			GroundSpeedKPH:   p.NullFloat64(6, "ground speed (km/h)"),
+		}, p.Err()
+	})
+
+	sentence := "$GPVTG,140.88,T,,M,8.04,N,14.89,K,D*05"
+	s, err := nmea.Parse(sentence)
+	if err != nil {
+		panic(err)
+	}
+
+	switch m := s.(type) {
+	case VTG:
+		fmt.Printf("Raw sentence: %v\n", m)
+		fmt.Printf("TrueTrack: %v\n", m.TrueTrack)
+		fmt.Printf("MagneticTrack: %v\n", m.MagneticTrack)
+		fmt.Printf("GroundSpeedKnots: %v\n", m.GroundSpeedKnots)
+		fmt.Printf("GroundSpeedKPH: %v\n", m.GroundSpeedKPH)
+	default:
+		panic("Could not parse VTG sentence")
+	}
+}
+```
+
+Output:
+
+```
+$ go run main/main.go
+
+Raw sentence: $GPVTG,140.88,T,,M,8.04,N,14.89,K,D*05
+TrueTrack: {140.88 true}
+MagneticTrack: {0 false}
+GroundSpeedKnots: {8.04 true}
+GroundSpeedKPH: {14.89 true}
+```
+
 ## Contributing
 
 Please feel free to submit issues or fork the repository and send pull requests to update the library and fix bugs,

--- a/parser.go
+++ b/parser.go
@@ -110,7 +110,7 @@ func (p *Parser) Int64(i int, context string) int64 {
 	return p.NullInt64(i, context).Value
 }
 
-// Int64 returns the int64 value at the specified index.
+// NullInt64 returns the int64 value at the specified index.
 // If the value is an empty string, Valid is set to false
 func (p *Parser) NullInt64(i int, context string) Int64 {
 	s := p.String(i, context)
@@ -134,7 +134,7 @@ func (p *Parser) Float64(i int, context string) float64 {
 	return p.NullFloat64(i, context).Value
 }
 
-// Float64 returns the Float64 value at the specified index.
+// NullFloat64 returns the Float64 value at the specified index.
 // If the value is an empty string, Valid is set to false.
 func (p *Parser) NullFloat64(i int, context string) Float64 {
 	s := p.String(i, context)

--- a/parser.go
+++ b/parser.go
@@ -107,35 +107,49 @@ func (p *Parser) EnumChars(i int, context string, options ...string) []string {
 // Int64 returns the int64 value at the specified index.
 // If the value is an empty string, 0 is returned.
 func (p *Parser) Int64(i int, context string) int64 {
+	return p.NullInt64(i, context).Value
+}
+
+// Int64 returns the int64 value at the specified index.
+// If the value is an empty string, Valid is set to false
+func (p *Parser) NullInt64(i int, context string) Int64 {
 	s := p.String(i, context)
 	if p.err != nil {
-		return 0
+		return Int64{}
 	}
 	if s == "" {
-		return 0
+		return Int64{}
 	}
 	v, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		p.SetErr(context, s)
+		return Int64{}
 	}
-	return v
+	return Int64{Value: v, Valid: true}
 }
 
 // Float64 returns the float64 value at the specified index.
 // If the value is an empty string, 0 is returned.
 func (p *Parser) Float64(i int, context string) float64 {
+	return p.NullFloat64(i, context).Value
+}
+
+// Float64 returns the Float64 value at the specified index.
+// If the value is an empty string, Valid is set to false.
+func (p *Parser) NullFloat64(i int, context string) Float64 {
 	s := p.String(i, context)
 	if p.err != nil {
-		return 0
+		return Float64{}
 	}
 	if s == "" {
-		return 0
+		return Float64{}
 	}
 	v, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		p.SetErr(context, s)
+		return Float64{}
 	}
-	return v
+	return Float64{Value: v, Valid: true}
 }
 
 // Time returns the Time value at the specified index.

--- a/parser_test.go
+++ b/parser_test.go
@@ -190,6 +190,76 @@ var parsertests = []struct {
 		},
 	},
 	{
+		name:     "NullInt64",
+		fields:   []string{"123"},
+		expected: Int64{Value: 123, Valid: true},
+		parse: func(p *Parser) interface{} {
+			return p.NullInt64(0, "context")
+		},
+	},
+	{
+		name:     "NullInt64 empty field is invalid",
+		fields:   []string{""},
+		expected: Int64{},
+		parse: func(p *Parser) interface{} {
+			return p.NullInt64(0, "context")
+		},
+	},
+	{
+		name:     "NullInt64 invalid",
+		fields:   []string{"abc"},
+		expected: Int64{},
+		hasErr:   true,
+		parse: func(p *Parser) interface{} {
+			return p.NullInt64(0, "context")
+		},
+	},
+	{
+		name:     "NullInt64 with existing error",
+		fields:   []string{"123"},
+		expected: Int64{},
+		hasErr:   true,
+		parse: func(p *Parser) interface{} {
+			p.SetErr("context", "value")
+			return p.NullInt64(0, "context")
+		},
+	},
+	{
+		name:     "NullFloat64",
+		fields:   []string{"123.123"},
+		expected: Float64{Value: 123.123, Valid: true},
+		parse: func(p *Parser) interface{} {
+			return p.NullFloat64(0, "context")
+		},
+	},
+	{
+		name:     "NullFloat64 empty field is invalid",
+		fields:   []string{""},
+		expected: Float64{},
+		parse: func(p *Parser) interface{} {
+			return p.NullFloat64(0, "context")
+		},
+	},
+	{
+		name:     "NullFloat64 invalid",
+		fields:   []string{"abc"},
+		expected: Float64{},
+		hasErr:   true,
+		parse: func(p *Parser) interface{} {
+			return p.NullFloat64(0, "context")
+		},
+	},
+	{
+		name:     "NullFloat64 with existing error",
+		fields:   []string{"123.123"},
+		expected: Float64{},
+		hasErr:   true,
+		parse: func(p *Parser) interface{} {
+			p.SetErr("context", "value")
+			return p.NullFloat64(0, "context")
+		},
+	},
+	{
 		name:     "Time",
 		fields:   []string{"123456"},
 		expected: Time{true, 12, 34, 56, 0},

--- a/types.go
+++ b/types.go
@@ -409,3 +409,15 @@ func LonDir(l float64) string {
 	}
 	return West
 }
+
+// Float64 is a nullable float64 value
+type Float64 struct {
+	Value float64
+	Valid bool
+}
+
+// Int64 is a nullable int64 value
+type Int64 struct {
+	Value int64
+	Valid bool
+}


### PR DESCRIPTION
As discussed in https://github.com/adrianmo/go-nmea/issues/79, here is a PR to help support optional values in NMEA sentences. Those are just helpers, which means that:
* Actual implementation of the sentence is left to the user.
* There's no breaking change in the current API.