### PR TITLE
Allow prefix with no talker ID

### DIFF
--- a/sentence.go
+++ b/sentence.go
@@ -176,6 +176,10 @@ func Parse(raw string) (Sentence, error) {
 	// Custom parser allow overriding of existing parsers
 	if parser, ok := customParsers[s.Type]; ok {
 		return parser(s)
+	} else if parser, ok := customParsers[s.Talker+s.Type]; ok {
+		s.Type = s.Talker + s.Type
+		s.Talker = ""
+		return parser(s)
 	}
 
 	if strings.HasPrefix(s.Raw, SentenceStart) {

--- a/sentence_customparser_test.go
+++ b/sentence_customparser_test.go
@@ -52,6 +52,21 @@ var customparsetests = []struct {
 		},
 	},
 	{
+		name: "zzz sentence without a talker ID",
+		raw:  "$ZZZ,30,two,*19",
+		msg: TestZZZ{
+			BaseSentence: BaseSentence{
+				Talker:   "",
+				Type:     "ZZZ",
+				Fields:   []string{"30", "two", ""},
+				Checksum: "19",
+				Raw:      "$ZZZ,30,two,*19",
+			},
+			NumberValue: 30,
+			StringValue: "two",
+		},
+	},
+	{
 		name: "zzz sentence type",
 		raw:  "$INVALID,123,123,*7D",
 		err:  "nmea: sentence prefix 'INVALID' not supported",


### PR DESCRIPTION
Hi,

I want to use this NMEA parser for a custom device which doesn't use talker ID's. This change adds a second check to the custom parsers to check for the full `talkerID + prefix` in the registered parsers instead of just the `prefix`.

This is the bare minimum to make this work, however happy to implement more edge-case handling if desired. I wasnt sure if this should be the first check on the custom parsers or second. Opted for the second to limit the chance of breaking anything.