### PR TITLE
Correct handling of navigational status in RMC and GNS

### DIFF
--- a/gns.go
+++ b/gns.go
@@ -79,13 +79,10 @@ func newGNS(s BaseSentence) (Sentence, error) {
 		m.NavStatus = p.EnumString(
 			12,
 			"navigation status",
-			NavStatusAutonomous,
-			NavStatusDifferential,
-			NavStatusEstimated,
-			NavStatusManualInput,
-			NavStatusSimulated,
-			NavStatusDataNotValid,
-			NavStatusDataValid,
+			NavStatusSafe,
+			NavStatusCaution,
+			NavStatusUnsafe,
+			NavStatusNotValid,
 		)
 	}
 	return m, p.Err()

--- a/rmc.go
+++ b/rmc.go
@@ -58,13 +58,10 @@ func newRMC(s BaseSentence) (Sentence, error) {
 		m.NavStatus = p.EnumString(
 			12,
 			"navigation status",
-			NavStatusAutonomous,
-			NavStatusDifferential,
-			NavStatusEstimated,
-			NavStatusManualInput,
-			NavStatusSimulated,
-			NavStatusDataNotValid,
-			NavStatusDataValid,
+			NavStatusSafe,
+			NavStatusCaution,
+			NavStatusUnsafe,
+			NavStatusNotValid,
 		)
 	}
 	return m, p.Err()

--- a/rmc_test.go
+++ b/rmc_test.go
@@ -110,13 +110,29 @@ var rmctests = []struct {
 			Date:      Date{Valid: true, DD: 30, MM: 5, YY: 18},
 			Variation: 0,
 			FFAMode:   FAAModeAutonomous,
-			NavStatus: NavStatusDataValid,
+			NavStatus: NavStatusNotValid,
 		},
 	},
 	{
 		name: "bad validity",
 		raw:  "$GPRMC,220516,D,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*75",
 		err:  "nmea: GPRMC invalid validity: D",
+	},
+	{
+		name: "good sentence G with nav status",
+		raw:  "$YDRMC,124014.00,A,5520.2848,N,01321.5108,E,0.0,0.0,230623,4.4,E,A,C*5D",
+		msg: RMC{
+			Time:      Time{Valid: true, Hour: 12, Minute: 40, Second: 14, Millisecond: 0},
+			Validity:  "A",
+			Latitude:  55.338080000000005,
+			Longitude: 13.358513333333333,
+			Speed:     0,
+			Course:    0,
+			Date:      Date{Valid: true, DD: 23, MM: 6, YY: 23},
+			Variation: 4.4,
+			FFAMode:   FAAModeAutonomous,
+			NavStatus: NavStatusCaution,
+		},
 	},
 }
 

--- a/types.go
+++ b/types.go
@@ -127,20 +127,14 @@ const (
 
 // Navigation Status (NMEA 4.1 and later)
 const (
-	// NavStatusAutonomous is Autonomous mode
-	NavStatusAutonomous = "A"
-	// NavStatusDifferential is Differential Mode
-	NavStatusDifferential = "D"
-	// NavStatusEstimated is Estimated (dead-reckoning) mode
-	NavStatusEstimated = "E"
-	// NavStatusManualInput is Manual Input Mode
-	NavStatusManualInput = "M"
-	// NavStatusSimulated is Simulated Mode
-	NavStatusSimulated = "S"
-	// NavStatusDataNotValid is Data Not Valid
-	NavStatusDataNotValid = "N"
-	// NavStatusDataValid is valid
-	NavStatusDataValid = "V"
+	// NavStatusSafe is Safe (within selected accuracy level)
+	NavStatusSafe = "S"
+	// NavStatusCaution is Caution (integrity not available)
+	NavStatusCaution = "C"
+	// NavStatusUnsafe is Unsafe (outside selected accuracy level)
+	NavStatusUnsafe = "U"
+	// NavStatusNotValid is Not Valid (equipment does not provide navigation status information)
+	NavStatusNotValid = "V"
 )
 
 const (

--- a/types.go
+++ b/types.go
@@ -127,6 +127,14 @@ const (
 
 // Navigation Status (NMEA 4.1 and later)
 const (
+	// NavStatusSimulated is a deprecated placeholder for backwards
+	// compatibility. There is no such status in NMEA.
+	// Deprecated: use NavStatusSafe
+	NavStatusSimulated = "S"
+	// NavStatusDataValid is a deprecated placeholder for backwards
+	// compatibility. There is no such status in NMEA.
+	// Deprecated: use NavStatusNotValid
+	NavStatusDataValid = "V"
 	// NavStatusSafe is Safe (within selected accuracy level)
 	NavStatusSafe = "S"
 	// NavStatusCaution is Caution (integrity not available)


### PR DESCRIPTION
There was a misunderstanding on what the "navigation status" field should include. The enum values were for the "positioning system mode indicator" (variously "FAA mode" / "FFA mode" in this code) which is the preceding field. This changes the enum values to correspond to actual ones.

I realize that in principle this is a breaking change, however there's no such thing (as far as I can tell) as the previous navigational status values (as those are in fact mode values, which we don't keep an enum for), so I doubt anyone should depend on them... If they do, that will be a bug by itself and breaking it to highlight the error may be desirable.

Fixes #107 