### PR TITLE
Add support for missing values in VHW sentence

### DIFF
--- a/vhw.go
+++ b/vhw.go
@@ -12,10 +12,10 @@ const (
 // Example: $VWVHW,45.0,T,43.0,M,3.5,N,6.4,K*56
 type VHW struct {
 	BaseSentence
-	TrueHeading            float64
-	MagneticHeading        float64
-	SpeedThroughWaterKnots float64
-	SpeedThroughWaterKPH   float64
+	TrueHeading            Float64
+	MagneticHeading        Float64
+	SpeedThroughWaterKnots Float64
+	SpeedThroughWaterKPH   Float64
 }
 
 // newVHW constructor
@@ -24,9 +24,9 @@ func newVHW(s BaseSentence) (Sentence, error) {
 	p.AssertType(TypeVHW)
 	return VHW{
 		BaseSentence:           s,
-		TrueHeading:            p.Float64(0, "true heading"),
-		MagneticHeading:        p.Float64(2, "magnetic heading"),
-		SpeedThroughWaterKnots: p.Float64(4, "speed through water in knots"),
-		SpeedThroughWaterKPH:   p.Float64(6, "speed through water in kilometers per hour"),
+		TrueHeading:            p.NullFloat64(0, "true heading"),
+		MagneticHeading:        p.NullFloat64(2, "magnetic heading"),
+		SpeedThroughWaterKnots: p.NullFloat64(4, "speed through water in knots"),
+		SpeedThroughWaterKPH:   p.NullFloat64(6, "speed through water in kilometers per hour"),
 	}, p.Err()
 }

--- a/vhw_test.go
+++ b/vhw_test.go
@@ -16,10 +16,20 @@ var vhw = []struct {
 		name: "good sentence",
 		raw:  "$VWVHW,45.0,T,43.0,M,3.5,N,6.4,K*56",
 		msg: VHW{
-			TrueHeading:            45.0,
-			MagneticHeading:        43.0,
-			SpeedThroughWaterKnots: 3.5,
-			SpeedThroughWaterKPH:   6.4,
+			TrueHeading:            Float64{Value: 45.0, Valid: true},
+			MagneticHeading:        Float64{Value: 43.0, Valid: true},
+			SpeedThroughWaterKnots: Float64{Value: 3.5, Valid: true},
+			SpeedThroughWaterKPH:   Float64{Value: 6.4, Valid: true},
+		},
+	},
+	{
+		name: "partial sentence",
+		raw:  "$INVHW,187.9,T,,,19.6,N,36.3,K*3E",
+		msg: VHW{
+			TrueHeading:            Float64{Value: 187.9, Valid: true},
+			MagneticHeading:        Float64{Value: 0, Valid: false},
+			SpeedThroughWaterKnots: Float64{Value: 19.6, Valid: true},
+			SpeedThroughWaterKPH:   Float64{Value: 36.3, Valid: true},
 		},
 	},
 	{


### PR DESCRIPTION
👋 Hey,

We have a NMEA talker that sends partial VHW sentences. It sends a True Heading, but not a Magnetic Heading.

We need to distinguish when these values are coming in empty so that we can ignore them in our system, but currently there is no way to do that without also ignoring `0.0` values.

To fix this I've changed the types for this sentence to be nullable float's.