### PR TITLE
Add support for returning nullable fields as `NaN`/`MAX_INT` when empty

### DIFF
--- a/aam.go
+++ b/aam.go
@@ -35,8 +35,8 @@ type AAM struct {
 }
 
 // newAAM constructor
-func newAAM(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newAAM(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeAAM)
 	return AAM{
 		BaseSentence:               s,

--- a/abm.go
+++ b/abm.go
@@ -41,8 +41,8 @@ type ABM struct {
 }
 
 // newABM constructor
-func newABM(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newABM(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeABM)
 	return ABM{
 		BaseSentence:     s,

--- a/ack.go
+++ b/ack.go
@@ -20,8 +20,8 @@ type ACK struct {
 }
 
 // newACKN constructor
-func newACK(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newACK(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeACK)
 	return ACK{
 		BaseSentence:    s,

--- a/acn.go
+++ b/acn.go
@@ -40,8 +40,8 @@ type ACN struct {
 }
 
 // newACN constructor
-func newACN(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newACN(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeACN)
 	return ACN{
 		BaseSentence:             s,

--- a/ala.go
+++ b/ala.go
@@ -51,8 +51,8 @@ type ALA struct {
 }
 
 // newALA constructor
-func newALA(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newALA(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeALA)
 	return ALA{
 		BaseSentence:       s,

--- a/alc.go
+++ b/alc.go
@@ -48,8 +48,8 @@ type ALCAlertEntry struct {
 }
 
 // newALC constructor
-func newALC(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newALC(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeALC)
 	alc := ALC{
 		BaseSentence:   s,

--- a/alf.go
+++ b/alf.go
@@ -70,8 +70,8 @@ type ALF struct {
 }
 
 // newALF constructor
-func newALF(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newALF(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeALF)
 	return ALF{
 		BaseSentence:             s,

--- a/alr.go
+++ b/alr.go
@@ -34,8 +34,8 @@ type ALR struct {
 }
 
 // newALR constructor
-func newALR(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newALR(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeALR)
 	return ALR{
 		BaseSentence:    s,

--- a/apb.go
+++ b/apb.go
@@ -104,8 +104,8 @@ type APB struct {
 }
 
 // newAPB constructor
-func newAPB(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newAPB(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeAPB)
 	apb := APB{
 		BaseSentence:               s,

--- a/arc.go
+++ b/arc.go
@@ -45,8 +45,8 @@ type ARC struct {
 }
 
 // newARC constructor
-func newARC(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newARC(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeARC)
 	return ARC{
 		BaseSentence:             s,

--- a/bbm.go
+++ b/bbm.go
@@ -38,8 +38,8 @@ type BBM struct {
 }
 
 // newBBM constructor
-func newBBM(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newBBM(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeBBM)
 	m := BBM{
 		BaseSentence:     s,

--- a/bec.go
+++ b/bec.go
@@ -26,8 +26,8 @@ type BEC struct {
 }
 
 // newBEC constructor
-func newBEC(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newBEC(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeBEC)
 	return BEC{
 		BaseSentence:               s,

--- a/bod.go
+++ b/bod.go
@@ -24,8 +24,8 @@ type BOD struct {
 }
 
 // newBOD constructor
-func newBOD(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newBOD(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeBOD)
 	bod := BOD{
 		BaseSentence:          s,

--- a/bwc.go
+++ b/bwc.go
@@ -29,8 +29,8 @@ type BWC struct {
 }
 
 // newBWC constructor
-func newBWC(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newBWC(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeBWC)
 	bwc := BWC{
 		BaseSentence:              s,

--- a/bwr.go
+++ b/bwr.go
@@ -28,8 +28,8 @@ type BWR struct {
 }
 
 // newBWR constructor
-func newBWR(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newBWR(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeBWR)
 	bwc := BWR{
 		BaseSentence:              s,

--- a/bww.go
+++ b/bww.go
@@ -24,8 +24,8 @@ type BWW struct {
 }
 
 // newBWW constructor
-func newBWW(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newBWW(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeBWW)
 	bod := BWW{
 		BaseSentence:          s,

--- a/dbk.go
+++ b/dbk.go
@@ -22,8 +22,8 @@ type DBK struct {
 }
 
 // newDBK constructor
-func newDBK(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newDBK(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeDBK)
 	return DBK{
 		BaseSentence:     s,

--- a/dbs.go
+++ b/dbs.go
@@ -22,8 +22,8 @@ type DBS struct {
 }
 
 // newDBS constructor
-func newDBS(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newDBS(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeDBS)
 	return DBS{
 		BaseSentence:    s,

--- a/dbt.go
+++ b/dbt.go
@@ -18,8 +18,8 @@ type DBT struct {
 }
 
 // newDBT constructor
-func newDBT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newDBT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeDBT)
 	return DBT{
 		BaseSentence: s,

--- a/dor.go
+++ b/dor.go
@@ -79,8 +79,8 @@ type DOR struct {
 }
 
 // newDOR constructor
-func newDOR(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newDOR(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeDOR)
 	return DOR{
 		BaseSentence:       s,

--- a/dpt.go
+++ b/dpt.go
@@ -19,8 +19,8 @@ type DPT struct {
 }
 
 // newDPT constructor
-func newDPT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newDPT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeDPT)
 	dpt := DPT{
 		BaseSentence: s,

--- a/dsc.go
+++ b/dsc.go
@@ -105,8 +105,8 @@ type DSC struct {
 }
 
 // newDSC constructor
-func newDSC(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newDSC(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeDSC)
 	return DSC{
 		BaseSentence:                s,

--- a/dse.go
+++ b/dse.go
@@ -48,8 +48,8 @@ type DSEDataSet struct {
 }
 
 // newDSE constructor
-func newDSE(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newDSE(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeDSE)
 	dse := DSE{
 		BaseSentence:    s,

--- a/dtm.go
+++ b/dtm.go
@@ -24,8 +24,8 @@ type DTM struct {
 }
 
 // newDTM constructor
-func newDTM(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newDTM(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeDTM)
 	m := DTM{
 		BaseSentence:      s,

--- a/eve.go
+++ b/eve.go
@@ -20,8 +20,8 @@ type EVE struct {
 }
 
 // newEVE constructor
-func newEVE(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newEVE(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeEVE)
 	return EVE{
 		BaseSentence: s,

--- a/fir.go
+++ b/fir.go
@@ -84,8 +84,8 @@ type FIR struct {
 }
 
 // newFIR constructor
-func newFIR(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newFIR(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeFIR)
 	return FIR{
 		BaseSentence:              s,

--- a/gga.go
+++ b/gga.go
@@ -40,8 +40,8 @@ type GGA struct {
 }
 
 // newGGA constructor
-func newGGA(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newGGA(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeGGA)
 	return GGA{
 		BaseSentence:  s,

--- a/gll.go
+++ b/gll.go
@@ -27,8 +27,8 @@ type GLL struct {
 }
 
 // newGLL constructor
-func newGLL(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newGLL(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeGLL)
 	gll := GLL{
 		BaseSentence: s,

--- a/gns.go
+++ b/gns.go
@@ -59,8 +59,8 @@ type GNS struct {
 }
 
 // newGNS Constructor
-func newGNS(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newGNS(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeGNS)
 	m := GNS{
 		BaseSentence: s,

--- a/gsa.go
+++ b/gsa.go
@@ -42,8 +42,8 @@ type GSA struct {
 }
 
 // newGSA parses the GSA sentence into this struct.
-func newGSA(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newGSA(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeGSA)
 	m := GSA{
 		BaseSentence: s,

--- a/gsv.go
+++ b/gsv.go
@@ -38,8 +38,8 @@ type GSVInfo struct {
 }
 
 // newGSV constructor
-func newGSV(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newGSV(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeGSV)
 	m := GSV{
 		BaseSentence:    s,

--- a/hbt.go
+++ b/hbt.go
@@ -21,8 +21,8 @@ type HBT struct {
 }
 
 // newHBT constructor
-func newHBT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newHBT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeHBT)
 	m := HBT{
 		BaseSentence:    s,

--- a/hdg.go
+++ b/hdg.go
@@ -21,8 +21,8 @@ type HDG struct {
 }
 
 // newHDG constructor
-func newHDG(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newHDG(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeHDG)
 	m := HDG{
 		BaseSentence:       s,

--- a/hdm.go
+++ b/hdm.go
@@ -19,8 +19,8 @@ type HDM struct {
 }
 
 // newHDM constructor
-func newHDM(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newHDM(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeHDM)
 	m := HDM{
 		BaseSentence:  s,

--- a/hdt.go
+++ b/hdt.go
@@ -18,8 +18,8 @@ type HDT struct {
 }
 
 // newHDT constructor
-func newHDT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newHDT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeHDT)
 	m := HDT{
 		BaseSentence: s,

--- a/hsc.go
+++ b/hsc.go
@@ -20,8 +20,8 @@ type HSC struct {
 }
 
 // newHSC constructor
-func newHSC(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newHSC(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeHSC)
 	return HSC{
 		BaseSentence:        s,

--- a/mda.go
+++ b/mda.go
@@ -83,8 +83,8 @@ type MDA struct {
 	MetersValid           bool // M
 }
 
-func newMDA(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newMDA(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeMDA)
 	return MDA{
 		BaseSentence:          s,

--- a/mta.go
+++ b/mta.go
@@ -17,8 +17,8 @@ type MTA struct {
 }
 
 // newMTA constructor
-func newMTA(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newMTA(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeMTA)
 	return MTA{
 		BaseSentence: s,

--- a/mtk.go
+++ b/mtk.go
@@ -33,8 +33,8 @@ type MTK struct {
 
 // newMTK constructor
 // Deprecated: use newPMTK001 instead
-func newMTK(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newMTK(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeMTK)
 	cmd := p.Int64(0, "command")
 	flag := p.Int64(1, "flag")

--- a/mtw.go
+++ b/mtw.go
@@ -19,8 +19,8 @@ type MTW struct {
 }
 
 // newMTW constructor
-func newMTW(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newMTW(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeMTW)
 	return MTW{
 		BaseSentence: s,

--- a/mwd.go
+++ b/mwd.go
@@ -50,8 +50,8 @@ type MWD struct {
 	MetersValid           bool
 }
 
-func newMWD(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newMWD(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeMWD)
 	return MWD{
 		BaseSentence:          s,

--- a/mwv.go
+++ b/mwv.go
@@ -61,8 +61,8 @@ type MWV struct {
 	StatusValid   bool
 }
 
-func newMWV(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newMWV(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeMWV)
 	return MWV{
 		BaseSentence:  s,

--- a/osd.go
+++ b/osd.go
@@ -68,8 +68,8 @@ type OSD struct {
 }
 
 // newOSD constructor
-func newOSD(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newOSD(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeOSD)
 	m := OSD{
 		BaseSentence:     s,

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package nmea
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 )
 
@@ -153,12 +154,17 @@ func (p *Parser) Float64(i int, context string) float64 {
 
 // NullFloat64 returns the Float64 value at the specified index.
 // If the value is an empty string, Valid is set to false.
+// When BaseSentence.NaNForEmptyFloat is true, empty fields return Float64{Value: math.NaN(), Valid: false}
+// instead of Float64{Value: 0, Valid: false}.
 func (p *Parser) NullFloat64(i int, context string) Float64 {
 	s := p.String(i, context)
 	if p.err != nil {
 		return Float64{}
 	}
 	if s == "" {
+		if p.NaNForEmptyFloat {
+			return Float64{Value: math.NaN(), Valid: false}
+		}
 		return Float64{}
 	}
 	v, err := strconv.ParseFloat(s, 64)

--- a/parser.go
+++ b/parser.go
@@ -129,13 +129,18 @@ func (p *Parser) Int64(i int, context string) int64 {
 }
 
 // NullInt64 returns the int64 value at the specified index.
-// If the value is an empty string, Valid is set to false
+// If the value is an empty string, Valid is set to false.
+// When BaseSentence.MaxInt64ForEmptyInt is true, empty fields return Int64{Value: math.MaxInt64, Valid: false}
+// instead of Int64{Value: 0, Valid: false}.
 func (p *Parser) NullInt64(i int, context string) Int64 {
 	s := p.String(i, context)
 	if p.err != nil {
 		return Int64{}
 	}
 	if s == "" {
+		if p.MaxInt64ForEmptyInt {
+			return Int64{Value: math.MaxInt64, Valid: false}
+		}
 		return Int64{}
 	}
 	v, err := strconv.ParseInt(s, 10, 64)

--- a/parser.go
+++ b/parser.go
@@ -6,16 +6,47 @@ import (
 	"strconv"
 )
 
+// ParserOption is a functional option for configuring a Parser.
+type ParserOption func(*Parser)
+
+// WithNaNForEmptyFloat configures the parser to return math.NaN() for empty float64 fields
+// instead of 0. NullFloat64 will return Float64{Value: math.NaN(), Valid: false} for empty fields.
+func WithNaNForEmptyFloat(enabled bool) ParserOption {
+	return func(p *Parser) {
+		p.NaNForEmptyFloat = enabled
+	}
+}
+
+// WithMaxInt64ForEmptyInt configures the parser to return math.MaxInt64 for empty int64 fields
+// instead of 0. NullInt64 will return Int64{Value: math.MaxInt64, Valid: false} for empty fields.
+func WithMaxInt64ForEmptyInt(enabled bool) ParserOption {
+	return func(p *Parser) {
+		p.MaxInt64ForEmptyInt = enabled
+	}
+}
+
 // Parser provides a simple way of accessing and parsing
 // sentence fields
 type Parser struct {
 	BaseSentence
 	err error
+
+	// NaNForEmptyFloat when true causes NullFloat64/Float64 to return math.NaN() for empty fields
+	// instead of 0. This allows distinguishing between empty/missing fields and fields with value 0.0.
+	NaNForEmptyFloat bool
+
+	// MaxInt64ForEmptyInt when true causes NullInt64/Int64 to return math.MaxInt64 for empty fields
+	// instead of 0. This allows distinguishing between empty/missing fields and fields with value 0.
+	MaxInt64ForEmptyInt bool
 }
 
 // NewParser constructor
-func NewParser(s BaseSentence) *Parser {
-	return &Parser{BaseSentence: s}
+func NewParser(s BaseSentence, opts ...ParserOption) *Parser {
+	p := &Parser{BaseSentence: s}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // AssertType makes sure the sentence's type matches the provided one.
@@ -130,7 +161,7 @@ func (p *Parser) Int64(i int, context string) int64 {
 
 // NullInt64 returns the int64 value at the specified index.
 // If the value is an empty string, Valid is set to false.
-// When BaseSentence.MaxInt64ForEmptyInt is true, empty fields return Int64{Value: math.MaxInt64, Valid: false}
+// When Parser.MaxInt64ForEmptyInt is true, empty fields return Int64{Value: math.MaxInt64, Valid: false}
 // instead of Int64{Value: 0, Valid: false}.
 func (p *Parser) NullInt64(i int, context string) Int64 {
 	s := p.String(i, context)
@@ -159,7 +190,7 @@ func (p *Parser) Float64(i int, context string) float64 {
 
 // NullFloat64 returns the Float64 value at the specified index.
 // If the value is an empty string, Valid is set to false.
-// When BaseSentence.NaNForEmptyFloat is true, empty fields return Float64{Value: math.NaN(), Valid: false}
+// When Parser.NaNForEmptyFloat is true, empty fields return Float64{Value: math.NaN(), Valid: false}
 // instead of Float64{Value: 0, Valid: false}.
 func (p *Parser) NullFloat64(i int, context string) Float64 {
 	s := p.String(i, context)

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,6 +1,7 @@
 package nmea
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -364,6 +365,45 @@ func TestParser(t *testing.T) {
 			parse: func(p *Parser) interface{} {
 				p.SetErr("context", "value")
 				return p.LatLong(0, 1, "context")
+			},
+		},
+		{
+			name:   "Float64 empty field is NaN when NaNForEmptyFloat is set",
+			fields: []string{""},
+			parse: func(p *Parser) interface{} {
+				p.NaNForEmptyFloat = true
+				v := p.Float64(0, "context")
+				assert.True(t, math.IsNaN(v))
+				return nil
+			},
+		},
+		{
+			name:   "NullFloat64 empty field returns NaN when NaNForEmptyFloat is set",
+			fields: []string{""},
+			parse: func(p *Parser) interface{} {
+				p.NaNForEmptyFloat = true
+				v := p.NullFloat64(0, "context")
+				assert.True(t, math.IsNaN(v.Value))
+				assert.False(t, v.Valid)
+				return nil
+			},
+		},
+		{
+			name:     "NullFloat64 non-empty field unaffected by NaNForEmptyFloat",
+			fields:   []string{"123.456"},
+			expected: Float64{Value: 123.456, Valid: true},
+			parse: func(p *Parser) interface{} {
+				p.NaNForEmptyFloat = true
+				return p.NullFloat64(0, "context")
+			},
+		},
+		{
+			name:     "NullFloat64 zero value unaffected by NaNForEmptyFloat",
+			fields:   []string{"0"},
+			expected: Float64{Value: 0, Valid: true},
+			parse: func(p *Parser) interface{} {
+				p.NaNForEmptyFloat = true
+				return p.NullFloat64(0, "context")
 			},
 		},
 		{

--- a/parser_test.go
+++ b/parser_test.go
@@ -227,6 +227,42 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
+			name:     "Int64 empty field is MaxInt64 when MaxInt64ForEmptyInt is set",
+			fields:   []string{""},
+			expected: int64(math.MaxInt64),
+			parse: func(p *Parser) interface{} {
+				p.MaxInt64ForEmptyInt = true
+				return p.Int64(0, "context")
+			},
+		},
+		{
+			name:     "NullInt64 empty field returns MaxInt64 when MaxInt64ForEmptyInt is set",
+			fields:   []string{""},
+			expected: Int64{Value: math.MaxInt64, Valid: false},
+			parse: func(p *Parser) interface{} {
+				p.MaxInt64ForEmptyInt = true
+				return p.NullInt64(0, "context")
+			},
+		},
+		{
+			name:     "NullInt64 non-empty field unaffected by MaxInt64ForEmptyInt",
+			fields:   []string{"456"},
+			expected: Int64{Value: 456, Valid: true},
+			parse: func(p *Parser) interface{} {
+				p.MaxInt64ForEmptyInt = true
+				return p.NullInt64(0, "context")
+			},
+		},
+		{
+			name:     "NullInt64 zero value unaffected by MaxInt64ForEmptyInt",
+			fields:   []string{"0"},
+			expected: Int64{Value: 0, Valid: true},
+			parse: func(p *Parser) interface{} {
+				p.MaxInt64ForEmptyInt = true
+				return p.NullInt64(0, "context")
+			},
+		},
+		{
 			name:     "NullFloat64",
 			fields:   []string{"123.123"},
 			expected: Float64{Value: 123.123, Valid: true},

--- a/pashr.go
+++ b/pashr.go
@@ -71,8 +71,8 @@ type PASHR struct {
 }
 
 // newPASHR constructor
-func newPASHR(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPASHR(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePASHR)
 	return PASHR{
 		BaseSentence:       s,

--- a/pcdin.go
+++ b/pcdin.go
@@ -27,8 +27,8 @@ type PCDIN struct {
 }
 
 // newPCDIN constructor
-func newPCDIN(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPCDIN(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePCDIN)
 
 	if len(p.Fields) != 4 {

--- a/pgn.go
+++ b/pgn.go
@@ -26,8 +26,8 @@ type PGN struct {
 }
 
 // newPGN constructor
-func newPGN(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPGN(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePGN)
 
 	if len(p.Fields) != 3 {

--- a/pgrme.go
+++ b/pgrme.go
@@ -21,8 +21,8 @@ type PGRME struct {
 }
 
 // newPGRME constructor
-func newPGRME(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPGRME(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePGRME)
 
 	horizontal := p.Float64(0, "horizontal error")

--- a/pgrmt.go
+++ b/pgrmt.go
@@ -34,8 +34,8 @@ type PGRMT struct {
 }
 
 // newPGRMT constructor
-func newPGRMT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPGRMT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePGRMT)
 
 	return PGRMT{

--- a/phtro.go
+++ b/phtro.go
@@ -27,8 +27,8 @@ type PHTRO struct {
 }
 
 // newPHTRO constructor
-func newPHTRO(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPHTRO(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePHTRO)
 	m := PHTRO{
 		BaseSentence: s,

--- a/pklds.go
+++ b/pklds.go
@@ -32,8 +32,8 @@ type PKLDS struct {
 }
 
 // newPKLDS constructor
-func newPKLDS(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPKLDS(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePKLDS)
 	m := PKLDS{
 		BaseSentence:    s,

--- a/pklid.go
+++ b/pklid.go
@@ -19,8 +19,8 @@ type PKLID struct {
 }
 
 // newPKLID constructor
-func newPKLID(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPKLID(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePKLID)
 
 	return PKLID{

--- a/pklsh.go
+++ b/pklsh.go
@@ -23,8 +23,8 @@ type PKLSH struct {
 }
 
 // newPKLSH constructor
-func newPKLSH(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPKLSH(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePKLSH)
 
 	return PKLSH{

--- a/pknds.go
+++ b/pknds.go
@@ -31,8 +31,8 @@ type PKNDS struct {
 }
 
 // newPKNDS constructor
-func newPKNDS(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPKNDS(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePKNDS)
 	m := PKNDS{
 		BaseSentence:    s,

--- a/pknid.go
+++ b/pknid.go
@@ -18,8 +18,8 @@ type PKNID struct {
 }
 
 // newPKNID constructor
-func newPKNID(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPKNID(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePKNID)
 
 	return PKNID{

--- a/pknsh.go
+++ b/pknsh.go
@@ -22,8 +22,8 @@ type PKNSH struct {
 }
 
 // newPKNSH constructor
-func newPKNSH(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPKNSH(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePKNSH)
 
 	return PKNSH{

--- a/pkwdwpl.go
+++ b/pkwdwpl.go
@@ -25,8 +25,8 @@ type PKWDWPL struct {
 }
 
 // newPKWDWPL constructor
-func newPKWDWPL(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPKWDWPL(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePKWDWPL)
 	m := PKWDWPL{
 		BaseSentence: s,

--- a/pmtk.go
+++ b/pmtk.go
@@ -29,8 +29,8 @@ type PMTK001 struct {
 }
 
 // newPMTK001 constructor
-func newPMTK001(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPMTK001(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 
 	cmd := p.Int64(0, "command")
 	flag := p.Int64(1, "flag")

--- a/prdid.go
+++ b/prdid.go
@@ -18,8 +18,8 @@ type PRDID struct {
 }
 
 // newPRDID constructor
-func newPRDID(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPRDID(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePRDID)
 	m := PRDID{
 		BaseSentence: s,

--- a/pskpdpt.go
+++ b/pskpdpt.go
@@ -29,8 +29,8 @@ type PSKPDPT struct {
 }
 
 // newPSKPDPT constructor
-func newPSKPDPT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPSKPDPT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePSKPDPT)
 	sentence := PSKPDPT{
 		BaseSentence:       s,

--- a/psoncms.go
+++ b/psoncms.go
@@ -31,8 +31,8 @@ type PSONCMS struct {
 }
 
 // newPSONCMS constructor
-func newPSONCMS(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newPSONCMS(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypePSONCMS)
 	m := PSONCMS{
 		BaseSentence:      s,

--- a/query.go
+++ b/query.go
@@ -17,8 +17,8 @@ type Query struct {
 }
 
 // newQuery constructor
-func newQuery(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newQuery(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeQuery)
 
 	return Query{

--- a/rmb.go
+++ b/rmb.go
@@ -65,8 +65,8 @@ type RMB struct {
 }
 
 // newRMB constructor
-func newRMB(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newRMB(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeRMB)
 	rmb := RMB{
 		BaseSentence:                    s,

--- a/rmc.go
+++ b/rmc.go
@@ -34,8 +34,8 @@ type RMC struct {
 }
 
 // newRMC constructor
-func newRMC(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newRMC(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeRMC)
 	m := RMC{
 		BaseSentence: s,

--- a/rot.go
+++ b/rot.go
@@ -20,8 +20,8 @@ type ROT struct {
 	Valid      bool    // "A" data valid,  "V" invalid data
 }
 
-func newROT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newROT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeROT)
 	return ROT{
 		BaseSentence: s,

--- a/rpm.go
+++ b/rpm.go
@@ -25,8 +25,8 @@ type RPM struct {
 }
 
 // newRPM constructor
-func newRPM(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newRPM(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeRPM)
 	return RPM{
 		BaseSentence: s,

--- a/rsa.go
+++ b/rsa.go
@@ -19,8 +19,8 @@ type RSA struct {
 }
 
 // newRSA constructor
-func newRSA(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newRSA(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeRSA)
 	return RSA{
 		BaseSentence:               s,

--- a/rsd.go
+++ b/rsd.go
@@ -41,8 +41,8 @@ type RSD struct {
 }
 
 // newRSD constructor
-func newRSD(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newRSD(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeRSD)
 	return RSD{
 		BaseSentence:         s,

--- a/rte.go
+++ b/rte.go
@@ -27,8 +27,8 @@ type RTE struct {
 }
 
 // newRTE constructor
-func newRTE(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newRTE(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeRTE)
 	return RTE{
 		BaseSentence:              s,

--- a/sentence.go
+++ b/sentence.go
@@ -63,6 +63,10 @@ type BaseSentence struct {
 	// NaNForEmptyFloat when true causes the parser to return math.NaN() for empty float64 fields
 	// instead of 0. This is propagated from SentenceParser.NaNForEmptyFloat.
 	NaNForEmptyFloat bool
+
+	// MaxInt64ForEmptyInt when true causes the parser to return math.MaxInt64 for empty int64 fields
+	// instead of 0. This is propagated from SentenceParser.MaxInt64ForEmptyInt.
+	MaxInt64ForEmptyInt bool
 }
 
 // Prefix returns the talker and type of message
@@ -119,6 +123,14 @@ type SentenceParser struct {
 	// Float64 (which returns NullFloat64.Value) will return math.NaN() for empty fields.
 	// This does not introduce breaking changes to the API as the struct field types remain float64.
 	NaNForEmptyFloat bool
+
+	// MaxInt64ForEmptyInt when set to true makes the parser return math.MaxInt64 as the value
+	// for empty int64 fields instead of 0. This allows distinguishing between a field
+	// that is empty/missing (MaxInt64) and a field that has value 0.
+	// NullInt64 will return Int64{Value: math.MaxInt64, Valid: false} for empty fields.
+	// Int64 (which returns NullInt64.Value) will return math.MaxInt64 for empty fields.
+	// This does not introduce breaking changes to the API as the struct field types remain int64.
+	MaxInt64ForEmptyInt bool
 }
 
 func (p *SentenceParser) parseBaseSentence(raw string) (BaseSentence, error) {
@@ -171,7 +183,8 @@ func (p *SentenceParser) parseBaseSentence(raw string) (BaseSentence, error) {
 		Checksum:         checksumRaw,
 		Raw:              raw,
 		TagBlock:         tagBlock,
-		NaNForEmptyFloat: p.NaNForEmptyFloat,
+		NaNForEmptyFloat:   p.NaNForEmptyFloat,
+		MaxInt64ForEmptyInt: p.MaxInt64ForEmptyInt,
 	}
 	if p.CheckCRC == nil {
 		err = CheckCRC(sentence, rawFields)

--- a/sentence.go
+++ b/sentence.go
@@ -59,14 +59,6 @@ type BaseSentence struct {
 	Checksum string   // The (raw) Checksum
 	Raw      string   // The raw NMEA sentence received
 	TagBlock TagBlock // NMEA tagblock
-
-	// NaNForEmptyFloat when true causes the parser to return math.NaN() for empty float64 fields
-	// instead of 0. This is propagated from SentenceParser.NaNForEmptyFloat.
-	NaNForEmptyFloat bool
-
-	// MaxInt64ForEmptyInt when true causes the parser to return math.MaxInt64 for empty int64 fields
-	// instead of 0. This is propagated from SentenceParser.MaxInt64ForEmptyInt.
-	MaxInt64ForEmptyInt bool
 }
 
 // Prefix returns the talker and type of message
@@ -121,7 +113,6 @@ type SentenceParser struct {
 	// that is empty/missing (NaN) and a field that has value 0.0.
 	// NullFloat64 will return Float64{Value: math.NaN(), Valid: false} for empty fields.
 	// Float64 (which returns NullFloat64.Value) will return math.NaN() for empty fields.
-	// This does not introduce breaking changes to the API as the struct field types remain float64.
 	NaNForEmptyFloat bool
 
 	// MaxInt64ForEmptyInt when set to true makes the parser return math.MaxInt64 as the value
@@ -129,8 +120,19 @@ type SentenceParser struct {
 	// that is empty/missing (MaxInt64) and a field that has value 0.
 	// NullInt64 will return Int64{Value: math.MaxInt64, Valid: false} for empty fields.
 	// Int64 (which returns NullInt64.Value) will return math.MaxInt64 for empty fields.
-	// This does not introduce breaking changes to the API as the struct field types remain int64.
 	MaxInt64ForEmptyInt bool
+}
+
+// parserOptions returns the ParserOption slice derived from the SentenceParser configuration.
+func (p *SentenceParser) parserOptions() []ParserOption {
+	var opts []ParserOption
+	if p.NaNForEmptyFloat {
+		opts = append(opts, WithNaNForEmptyFloat(true))
+	}
+	if p.MaxInt64ForEmptyInt {
+		opts = append(opts, WithMaxInt64ForEmptyInt(true))
+	}
+	return opts
 }
 
 func (p *SentenceParser) parseBaseSentence(raw string) (BaseSentence, error) {
@@ -177,14 +179,12 @@ func (p *SentenceParser) parseBaseSentence(raw string) (BaseSentence, error) {
 		return BaseSentence{}, err
 	}
 	sentence := BaseSentence{
-		Talker:           talkerID,
-		Type:             typ,
-		Fields:           fields[1:],
-		Checksum:         checksumRaw,
-		Raw:              raw,
-		TagBlock:         tagBlock,
-		NaNForEmptyFloat:   p.NaNForEmptyFloat,
-		MaxInt64ForEmptyInt: p.MaxInt64ForEmptyInt,
+		Talker:   talkerID,
+		Type:     typ,
+		Fields:   fields[1:],
+		Checksum: checksumRaw,
+		Raw:      raw,
+		TagBlock: tagBlock,
 	}
 	if p.CheckCRC == nil {
 		err = CheckCRC(sentence, rawFields)
@@ -254,7 +254,7 @@ var defaultSentenceParserMu = new(sync.Mutex)
 // to work as they did before SentenceParser was added.
 var defaultSentenceParser = SentenceParser{
 	CustomParsers: map[string]ParserFunc{
-		TypeMTK: newMTK, // for backwards compatibility support MTK. PMTK001 is correct an supported when using SentenceParser instance
+		TypeMTK: func(s BaseSentence) (Sentence, error) { return newMTK(s) }, // for backwards compatibility support MTK. PMTK001 is correct an supported when using SentenceParser instance
 	},
 }
 
@@ -305,186 +305,188 @@ func (p *SentenceParser) Parse(raw string) (Sentence, error) {
 		return parser(s)
 	}
 
+	opts := p.parserOptions()
+
 	if s.Raw[0] == SentenceStart[0] {
 		switch s.Type {
 		case TypeRMC:
-			return newRMC(s)
+			return newRMC(s, opts...)
 		case TypeAAM:
-			return newAAM(s)
+			return newAAM(s, opts...)
 		case TypeACK:
-			return newACK(s)
+			return newACK(s, opts...)
 		case TypeACN:
-			return newACN(s)
+			return newACN(s, opts...)
 		case TypeALA:
-			return newALA(s)
+			return newALA(s, opts...)
 		case TypeALC:
-			return newALC(s)
+			return newALC(s, opts...)
 		case TypeALF:
-			return newALF(s)
+			return newALF(s, opts...)
 		case TypeALR:
-			return newALR(s)
+			return newALR(s, opts...)
 		case TypeAPB:
-			return newAPB(s)
+			return newAPB(s, opts...)
 		case TypeARC:
-			return newARC(s)
+			return newARC(s, opts...)
 		case TypeBEC:
-			return newBEC(s)
+			return newBEC(s, opts...)
 		case TypeBOD:
-			return newBOD(s)
+			return newBOD(s, opts...)
 		case TypeBWC:
-			return newBWC(s)
+			return newBWC(s, opts...)
 		case TypeBWR:
-			return newBWR(s)
+			return newBWR(s, opts...)
 		case TypeBWW:
-			return newBWW(s)
+			return newBWW(s, opts...)
 		case TypeDOR:
-			return newDOR(s)
+			return newDOR(s, opts...)
 		case TypeDSC:
-			return newDSC(s)
+			return newDSC(s, opts...)
 		case TypeDSE:
-			return newDSE(s)
+			return newDSE(s, opts...)
 		case TypeDTM:
-			return newDTM(s)
+			return newDTM(s, opts...)
 		case TypeEVE:
-			return newEVE(s)
+			return newEVE(s, opts...)
 		case TypeFIR:
-			return newFIR(s)
+			return newFIR(s, opts...)
 		case TypeGGA:
-			return newGGA(s)
+			return newGGA(s, opts...)
 		case TypeGSA:
-			return newGSA(s)
+			return newGSA(s, opts...)
 		case TypeGLL:
-			return newGLL(s)
+			return newGLL(s, opts...)
 		case TypeVTG:
-			return newVTG(s)
+			return newVTG(s, opts...)
 		case TypeZDA:
-			return newZDA(s)
+			return newZDA(s, opts...)
 		case TypePGN:
-			return newPGN(s)
+			return newPGN(s, opts...)
 		case TypePCDIN:
-			return newPCDIN(s)
+			return newPCDIN(s, opts...)
 		case TypePGRME:
-			return newPGRME(s)
+			return newPGRME(s, opts...)
 		case TypePGRMT:
-			return newPGRMT(s)
+			return newPGRMT(s, opts...)
 		case TypePHTRO:
-			return newPHTRO(s)
+			return newPHTRO(s, opts...)
 		case TypePMTK001:
-			return newPMTK001(s)
+			return newPMTK001(s, opts...)
 		case TypePRDID:
-			return newPRDID(s)
+			return newPRDID(s, opts...)
 		case TypePSKPDPT:
-			return newPSKPDPT(s)
+			return newPSKPDPT(s, opts...)
 		case TypePSONCMS:
-			return newPSONCMS(s)
+			return newPSONCMS(s, opts...)
 		case TypeQuery:
-			return newQuery(s)
+			return newQuery(s, opts...)
 		case TypeGSV:
-			return newGSV(s)
+			return newGSV(s, opts...)
 		case TypeHBT:
-			return newHBT(s)
+			return newHBT(s, opts...)
 		case TypeHDG:
-			return newHDG(s)
+			return newHDG(s, opts...)
 		case TypeHDT:
-			return newHDT(s)
+			return newHDT(s, opts...)
 		case TypeHDM:
-			return newHDM(s)
+			return newHDM(s, opts...)
 		case TypeHSC:
-			return newHSC(s)
+			return newHSC(s, opts...)
 		case TypeGNS:
-			return newGNS(s)
+			return newGNS(s, opts...)
 		case TypeTHS:
-			return newTHS(s)
+			return newTHS(s, opts...)
 		case TypeTLB:
-			return newTLB(s)
+			return newTLB(s, opts...)
 		case TypeTLL:
-			return newTLL(s)
+			return newTLL(s, opts...)
 		case TypeTTM:
-			return newTTM(s)
+			return newTTM(s, opts...)
 		case TypeTXT:
-			return newTXT(s)
+			return newTXT(s, opts...)
 		case TypeWPL:
-			return newWPL(s)
+			return newWPL(s, opts...)
 		case TypeRMB:
-			return newRMB(s)
+			return newRMB(s, opts...)
 		case TypeRPM:
-			return newRPM(s)
+			return newRPM(s, opts...)
 		case TypeRSA:
-			return newRSA(s)
+			return newRSA(s, opts...)
 		case TypeRSD:
-			return newRSD(s)
+			return newRSD(s, opts...)
 		case TypeRTE:
-			return newRTE(s)
+			return newRTE(s, opts...)
 		case TypeROT:
-			return newROT(s)
+			return newROT(s, opts...)
 		case TypeVBW:
-			return newVBW(s)
+			return newVBW(s, opts...)
 		case TypeVDR:
-			return newVDR(s)
+			return newVDR(s, opts...)
 		case TypeVHW:
-			return newVHW(s)
+			return newVHW(s, opts...)
 		case TypeVSD:
-			return newVSD(s)
+			return newVSD(s, opts...)
 		case TypeVPW:
-			return newVPW(s)
+			return newVPW(s, opts...)
 		case TypeVLW:
-			return newVLW(s)
+			return newVLW(s, opts...)
 		case TypeVWR:
-			return newVWR(s)
+			return newVWR(s, opts...)
 		case TypeVWT:
-			return newVWT(s)
+			return newVWT(s, opts...)
 		case TypeDPT:
-			return newDPT(s)
+			return newDPT(s, opts...)
 		case TypeDBT:
-			return newDBT(s)
+			return newDBT(s, opts...)
 		case TypeDBK:
-			return newDBK(s)
+			return newDBK(s, opts...)
 		case TypeDBS:
-			return newDBS(s)
+			return newDBS(s, opts...)
 		case TypeMDA:
-			return newMDA(s)
+			return newMDA(s, opts...)
 		case TypeMTA:
-			return newMTA(s)
+			return newMTA(s, opts...)
 		case TypeMTW:
-			return newMTW(s)
+			return newMTW(s, opts...)
 		case TypeMWD:
-			return newMWD(s)
+			return newMWD(s, opts...)
 		case TypeMWV:
-			return newMWV(s)
+			return newMWV(s, opts...)
 		case TypeOSD:
-			return newOSD(s)
+			return newOSD(s, opts...)
 		case TypeXDR:
-			return newXDR(s)
+			return newXDR(s, opts...)
 		case TypeXTE:
-			return newXTE(s)
+			return newXTE(s, opts...)
 		case TypePKLID:
-			return newPKLID(s)
+			return newPKLID(s, opts...)
 		case TypePKNID:
-			return newPKNID(s)
+			return newPKNID(s, opts...)
 		case TypePKLSH:
-			return newPKLSH(s)
+			return newPKLSH(s, opts...)
 		case TypePKNSH:
-			return newPKNSH(s)
+			return newPKNSH(s, opts...)
 		case TypePKLDS:
-			return newPKLDS(s)
+			return newPKLDS(s, opts...)
 		case TypePKNDS:
-			return newPKNDS(s)
+			return newPKNDS(s, opts...)
 		case TypePKWDWPL:
-			return newPKWDWPL(s)
+			return newPKWDWPL(s, opts...)
 		case TypePASHR:
-			return newPASHR(s)
+			return newPASHR(s, opts...)
 		}
 	}
 	if s.Raw[0] == SentenceStartEncapsulated[0] {
 		switch s.Type {
 		case TypeABM:
-			return newABM(s)
+			return newABM(s, opts...)
 		case TypeBBM:
-			return newBBM(s)
+			return newBBM(s, opts...)
 		case TypeTTD:
-			return newTTD(s)
+			return newTTD(s, opts...)
 		case TypeVDM, TypeVDO:
-			return newVDMVDO(s)
+			return newVDMVDO(s, opts...)
 		}
 	}
 	return nil, &NotSupportedError{Prefix: s.Prefix()}

--- a/sentence.go
+++ b/sentence.go
@@ -59,6 +59,10 @@ type BaseSentence struct {
 	Checksum string   // The (raw) Checksum
 	Raw      string   // The raw NMEA sentence received
 	TagBlock TagBlock // NMEA tagblock
+
+	// NaNForEmptyFloat when true causes the parser to return math.NaN() for empty float64 fields
+	// instead of 0. This is propagated from SentenceParser.NaNForEmptyFloat.
+	NaNForEmptyFloat bool
 }
 
 // Prefix returns the talker and type of message
@@ -107,6 +111,14 @@ type SentenceParser struct {
 	// OnBaseSentence is a callback for accessing/modifying the base sentence
 	// before further parsing is done.
 	OnBaseSentence func(sentence *BaseSentence) error
+
+	// NaNForEmptyFloat when set to true makes the parser return math.NaN() as the value
+	// for empty float64 fields instead of 0. This allows distinguishing between a field
+	// that is empty/missing (NaN) and a field that has value 0.0.
+	// NullFloat64 will return Float64{Value: math.NaN(), Valid: false} for empty fields.
+	// Float64 (which returns NullFloat64.Value) will return math.NaN() for empty fields.
+	// This does not introduce breaking changes to the API as the struct field types remain float64.
+	NaNForEmptyFloat bool
 }
 
 func (p *SentenceParser) parseBaseSentence(raw string) (BaseSentence, error) {
@@ -153,12 +165,13 @@ func (p *SentenceParser) parseBaseSentence(raw string) (BaseSentence, error) {
 		return BaseSentence{}, err
 	}
 	sentence := BaseSentence{
-		Talker:   talkerID,
-		Type:     typ,
-		Fields:   fields[1:],
-		Checksum: checksumRaw,
-		Raw:      raw,
-		TagBlock: tagBlock,
+		Talker:           talkerID,
+		Type:             typ,
+		Fields:           fields[1:],
+		Checksum:         checksumRaw,
+		Raw:              raw,
+		TagBlock:         tagBlock,
+		NaNForEmptyFloat: p.NaNForEmptyFloat,
 	}
 	if p.CheckCRC == nil {
 		err = CheckCRC(sentence, rawFields)

--- a/ths.go
+++ b/ths.go
@@ -28,8 +28,8 @@ type THS struct {
 }
 
 // newTHS constructor
-func newTHS(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newTHS(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeTHS)
 	m := THS{
 		BaseSentence: s,

--- a/tlb.go
+++ b/tlb.go
@@ -26,8 +26,8 @@ type TLBTarget struct {
 }
 
 // newTLB constructor
-func newTLB(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newTLB(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeTLB)
 	tlb := TLB{
 		BaseSentence: s,

--- a/tll.go
+++ b/tll.go
@@ -30,8 +30,8 @@ type TLL struct {
 }
 
 // newTLL constructor
-func newTLL(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newTLL(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeTLL)
 	return TLL{
 		BaseSentence:    s,

--- a/ttd.go
+++ b/ttd.go
@@ -24,8 +24,8 @@ type TTD struct {
 }
 
 // newTTD constructor
-func newTTD(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newTTD(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeTTD)
 	m := TTD{
 		BaseSentence:   s,

--- a/ttm.go
+++ b/ttm.go
@@ -32,8 +32,8 @@ type TTM struct {
 }
 
 // newTTM constructor
-func newTTM(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newTTM(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeTTM)
 	return TTM{
 		BaseSentence:      s,

--- a/txt.go
+++ b/txt.go
@@ -25,8 +25,8 @@ type TXT struct {
 }
 
 // newTXT constructor
-func newTXT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newTXT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeTXT)
 	m := TXT{
 		BaseSentence: s,

--- a/vbw.go
+++ b/vbw.go
@@ -32,8 +32,8 @@ type VBW struct {
 }
 
 // newVBW constructor
-func newVBW(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVBW(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVBW)
 
 	m := VBW{

--- a/vdmvdo.go
+++ b/vdmvdo.go
@@ -24,8 +24,8 @@ type VDMVDO struct {
 }
 
 // newVDMVDO constructor
-func newVDMVDO(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVDMVDO(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	m := VDMVDO{
 		BaseSentence:   s,
 		NumFragments:   p.Int64(0, "number of fragments"),

--- a/vdr.go
+++ b/vdr.go
@@ -23,8 +23,8 @@ type VDR struct {
 }
 
 // newVDR constructor
-func newVDR(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVDR(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVDR)
 	return VDR{
 		BaseSentence:           s,

--- a/vhw.go
+++ b/vhw.go
@@ -19,8 +19,8 @@ type VHW struct {
 }
 
 // newVHW constructor
-func newVHW(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVHW(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVHW)
 	return VHW{
 		BaseSentence:           s,

--- a/vhw_test.go
+++ b/vhw_test.go
@@ -1,6 +1,7 @@
 package nmea
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,4 +45,33 @@ func TestVHW(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVHW_NaNForEmptyFloat(t *testing.T) {
+	// Test that SentenceParser with NaNForEmptyFloat returns NaN for empty float fields
+	p := SentenceParser{
+		NaNForEmptyFloat: true,
+	}
+
+	t.Run("partial sentence with NaN", func(t *testing.T) {
+		m, err := p.Parse("$INVHW,187.9,T,,,19.6,N,36.3,K*3E")
+		assert.NoError(t, err)
+		vhw := m.(VHW)
+
+		assert.Equal(t, 187.9, vhw.TrueHeading)
+		assert.True(t, math.IsNaN(vhw.MagneticHeading), "empty MagneticHeading should be NaN")
+		assert.Equal(t, 19.6, vhw.SpeedThroughWaterKnots)
+		assert.Equal(t, 36.3, vhw.SpeedThroughWaterKPH)
+	})
+
+	t.Run("full sentence unaffected", func(t *testing.T) {
+		m, err := p.Parse("$VWVHW,45.0,T,43.0,M,3.5,N,6.4,K*56")
+		assert.NoError(t, err)
+		vhw := m.(VHW)
+
+		assert.Equal(t, 45.0, vhw.TrueHeading)
+		assert.Equal(t, 43.0, vhw.MagneticHeading)
+		assert.Equal(t, 3.5, vhw.SpeedThroughWaterKnots)
+		assert.Equal(t, 6.4, vhw.SpeedThroughWaterKPH)
+	})
 }

--- a/vlw.go
+++ b/vlw.go
@@ -25,8 +25,8 @@ type VLW struct {
 }
 
 // newVLW constructor
-func newVLW(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVLW(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVLW)
 
 	vlw := VLW{

--- a/vpw.go
+++ b/vpw.go
@@ -19,8 +19,8 @@ type VPW struct {
 }
 
 // newVPW constructor
-func newVPW(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVPW(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVPW)
 	return VPW{
 		BaseSentence:   s,

--- a/vsd.go
+++ b/vsd.go
@@ -68,8 +68,8 @@ type VSD struct {
 }
 
 // newVSD constructor
-func newVSD(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVSD(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVSD)
 	m := VSD{
 		BaseSentence:          s,

--- a/vtg.go
+++ b/vtg.go
@@ -24,8 +24,8 @@ type VTG struct {
 
 // newVTG parses the VTG sentence into this struct.
 // e.g: $GPVTG,360.0,T,348.7,M,000.0,N,000.0,K*43
-func newVTG(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVTG(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVTG)
 	vtg := VTG{
 		BaseSentence:     s,

--- a/vwr.go
+++ b/vwr.go
@@ -27,8 +27,8 @@ type VWR struct {
 }
 
 // newVWR constructor
-func newVWR(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVWR(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVWR)
 	return VWR{
 		BaseSentence:         s,

--- a/vwt.go
+++ b/vwt.go
@@ -25,8 +25,8 @@ type VWT struct {
 }
 
 // newVWT constructor
-func newVWT(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newVWT(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeVWT)
 	return VWT{
 		BaseSentence:     s,

--- a/wpl.go
+++ b/wpl.go
@@ -19,8 +19,8 @@ type WPL struct {
 }
 
 // newWPL constructor
-func newWPL(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newWPL(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeWPL)
 	return WPL{
 		BaseSentence: s,

--- a/xdr.go
+++ b/xdr.go
@@ -102,8 +102,8 @@ type XDRMeasurement struct {
 }
 
 // newXDR constructor
-func newXDR(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newXDR(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeXDR)
 
 	xdr := XDR{

--- a/xte.go
+++ b/xte.go
@@ -42,8 +42,8 @@ type XTE struct {
 }
 
 // newXTE constructor
-func newXTE(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newXTE(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeXTE)
 	xte := XTE{
 		BaseSentence:             s,

--- a/zda.go
+++ b/zda.go
@@ -22,8 +22,8 @@ type ZDA struct {
 }
 
 // newZDA constructor
-func newZDA(s BaseSentence) (Sentence, error) {
-	p := NewParser(s)
+func newZDA(s BaseSentence, opts ...ParserOption) (Sentence, error) {
+	p := NewParser(s, opts...)
 	p.AssertType(TypeZDA)
 	return ZDA{
 		BaseSentence:  s,


### PR DESCRIPTION
👋 Hey,

This is a follow up to #121. It adds two flags to the sentence parser `NaNForEmptyFloat`/`MaxInt64ForEmptyInt` that return either `NaN`/`MAX_INT` whenever we find a field that is empty. 

The objective is to keep the existing interface and retain backwards compatibility while allowing options for users to detect empty fields with these special values.